### PR TITLE
Add no-thumb class for missing hero images

### DIFF
--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -30,7 +30,7 @@ const BasicPage = ({data}) => {
 			<SEO title={title} keywords={[`gatsby`, `application`, `react`]} />
 			
 			{ /**** Header and Title ****/ }
-			<div id="rotator">
+			<div className={!contentExists(imageData) && "no-thumb"} id="rotator">
 				<Hero imgData={imageData} />				
 				<div className="container ft-container">
 					<h1 className="fancy-title">{title}</h1>

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -386,7 +386,7 @@ function prepareVariantHeading (variantData) {
 	/>
 	<SEO title={title} keywords={[`gatsby`, `application`, `react`]} />
 	  { /**** Header and Title ****/ }
-	  <div id="rotator">
+	  <div className={!contentExists(imageData) && "no-thumb"} id="rotator">
 		{/* <FetchImages tags={imageTags} /> */}
 		{renderHeaderImage(imageData)}
 		<div className="container ft-container">


### PR DESCRIPTION
This is to shrink the height of the header area when no hero image is present