### PR TITLE
Remove gatsby-plugin-manifest to resolve 404 flash

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,18 +48,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-manifest`,
-      options: {
-        name: `Gatsby UG Starter Template`,
-        short_name: `UG starter`,
-        start_url: `/`,
-        background_color: `#FFFFFF`,
-        theme_color: `#000000`,
-        display: `browser`,
-        icon: `src/favicon.png`, // This path is relative to the root of the site.
-      },
-    },
-    {
       resolve: `gatsby-source-drupal`,
         options: {
         baseUrl: process.env.DRUPAL_BASEURL,


### PR DESCRIPTION
As per advice from Gatsby Support, this is a test to see if removing gatsby-plugin-manifest from gatsby-config.js will resolve the 404 flash error on the index page.