### PR TITLE
Use Azure domain as assetPrefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -95,5 +95,5 @@ module.exports = {
       }
     }
   ],
-  assetPrefix: "/assets/",
+  assetPrefix: "https://livechugendpoint.azureedge.net",
 }


### PR DESCRIPTION
This is an attempt to resolve the 404 flash that occurs with Gatsby Cloud URLs