### PR TITLE
Use environment variable for assetPrefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -78,9 +78,6 @@ module.exports = {
       },
     },    
     {
-      resolve: `gatsby-plugin-asset-path`,
-    },
-    {
       resolve: `gatsby-plugin-google-tagmanager`,
       options: {
         id: "GTM-NRSSDKW",


### PR DESCRIPTION
Change assetPrefix to use an environment variable instead of hardcoded value.