### PR TITLE
Upgrade Gatsby Cloud plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "gatsby-background-image": "^1.5.3",
         "gatsby-cli": "^3.14.0",
         "gatsby-image": "^3.11.0",
-        "gatsby-plugin-gatsby-cloud": "^3.2.0",
+        "gatsby-plugin-gatsby-cloud": "^3.2.1",
         "gatsby-plugin-google-analytics": "^3.14.0",
         "gatsby-plugin-google-tagmanager": "^3.14.0",
         "gatsby-plugin-image": "^1.14.0",
@@ -9587,9 +9587,9 @@
       }
     },
     "node_modules/gatsby-plugin-gatsby-cloud": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-3.2.0.tgz",
-      "integrity": "sha512-9s6HgwKY1ViLl1Zu5GfEf5lLkSAT2rzieOVnjb7OmId/K1+qzJgpnj2qe+4lMDigfp1hpuDjBmcPJLxfSttHgw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-3.2.1.tgz",
+      "integrity": "sha512-SRDa/n4A2o78zTEQXxZ7nMxBUp9S0JMS9YcfG74c5md2YCJeBAvGiIQGuCC4OtvKMB/U6qscgvoiNF8fG7g21Q==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "date-fns": "^2.23.0",
@@ -16737,6 +16737,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -31171,9 +31176,9 @@
       }
     },
     "gatsby-plugin-gatsby-cloud": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-3.2.0.tgz",
-      "integrity": "sha512-9s6HgwKY1ViLl1Zu5GfEf5lLkSAT2rzieOVnjb7OmId/K1+qzJgpnj2qe+4lMDigfp1hpuDjBmcPJLxfSttHgw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-gatsby-cloud/-/gatsby-plugin-gatsby-cloud-3.2.1.tgz",
+      "integrity": "sha512-SRDa/n4A2o78zTEQXxZ7nMxBUp9S0JMS9YcfG74c5md2YCJeBAvGiIQGuCC4OtvKMB/U6qscgvoiNF8fG7g21Q==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "date-fns": "^2.23.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gatsby-background-image": "^1.5.3",
     "gatsby-cli": "^3.14.0",
     "gatsby-image": "^3.11.0",
-    "gatsby-plugin-gatsby-cloud": "^3.2.0",
+    "gatsby-plugin-gatsby-cloud": "^3.2.1",
     "gatsby-plugin-google-analytics": "^3.14.0",
     "gatsby-plugin-google-tagmanager": "^3.14.0",
     "gatsby-plugin-image": "^1.14.0",


### PR DESCRIPTION
Implement [Properly set the pathPrefix and assetPrefix in the pluginData fix](https://github.com/gatsbyjs/gatsby/commits/gatsby-plugin-gatsby-cloud@3.2.1/packages/gatsby-plugin-gatsby-cloud)