### PR TITLE
Add Hero video option for Program pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -180,6 +180,8 @@ exports.createSchemaCustomization = ({ actions }) => {
       drupal_id: String
       name: String
       field_media_oembed_video: String
+      field_video_width: Int
+      field_video_height: Int
       relationships: media__remote_videoRelationships
     }
     type media__remote_videoRelationships implements Node {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-helmet": "^6.1.0",
         "react-inlinesvg": "^2.3.0",
         "react-number-format": "^4.7.3",
+        "react-player": "^2.9.0",
         "react-slick": "^0.28.1",
         "slick-carousel": "^1.8.1"
       },
@@ -12804,6 +12805,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "node_modules/loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -13295,6 +13301,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/memoizee": {
       "version": "0.4.15",
@@ -16738,6 +16749,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19499,6 +19515,21 @@
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0",
         "react-dom": "^0.14 || ^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
+      }
+    },
+    "node_modules/react-player": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.9.0.tgz",
+      "integrity": "sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA==",
+      "dependencies": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/react-refresh": {
@@ -33513,6 +33544,11 @@
         }
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -33908,6 +33944,11 @@
       "requires": {
         "fs-monkey": "1.0.3"
       }
+    },
+    "memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "memoizee": {
       "version": "0.4.15",
@@ -38340,6 +38381,18 @@
       "integrity": "sha512-4EvcANjstypQ5anhanmdEioGc49qbnErfS+yqbhatC0vzQ1okplkWNb0DIY7ABu4RhaxzttEz6pypEy8KsqgBQ==",
       "requires": {
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-player": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.9.0.tgz",
+      "integrity": "sha512-jNUkTfMmUhwPPAktAdIqiBcVUKsFKrVGH6Ocutj6535CNfM91yrvWxHg6fvIX8Y/fjYUPoejddwh7qboNV9vGA==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
       }
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-helmet": "^6.1.0",
     "react-inlinesvg": "^2.3.0",
     "react-number-format": "^4.7.3",
+    "react-player": "^2.9.0",
     "react-slick": "^0.28.1",
     "slick-carousel": "^1.8.1"
   },

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -1,46 +1,68 @@
-import React from 'react';
+import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
 import { contentExists } from '../utils/ug-utils';
 
-function HeroVideo (props) {
-	let playerID = props.playerID;
-	let videoCC = props.videoCC;
-    let videoSize = props.videoSize;
-	let videoTranscript = props.videoTranscript;
-	let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
-	let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
+class HeroVideo extends Component {
+    
+    state = {
+        playing: true,
+        muted: true,
+        loop: true
+    }
+    
+    ref = player => {
+        this.player = player
+    }
+    handlePlayPause = () => {
+        this.setState({ playing: !this.state.playing })
+    }
+    
+    render() {
+        let playerID = this.props.playerID;
+        let videoCC = this.props.videoCC;
+        let videoSize = this.props.videoSize;
+        let videoTranscript = this.props.videoTranscript;
+        let videoType = (this.props.videoURL.includes("youtube") || this.props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
+        let videoID = (videoType === `youtube` ? this.props.videoURL.substr(this.props.videoURL.length - 11) : this.props.videoURL.substr(18));
 
-	let youtubeURL = "https://www.youtube.com/embed/";
-	let vimeoURL = "https://player.vimeo.com/video/";	
-	let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
-	
-	return (
-		<React.Fragment>        
-        <div style="max-width:100%; max-height:60rem;" className={"embed-responsive embed-responsive-" + videoSize}>
-        <ReactPlayer url={videoSrc}
-            playing
-            loop
-            muted
-            width="100%"
-            height="100%"
-        />
-        </div>      
-        </React.Fragment>
-	)
+        let youtubeURL = "https://www.youtube.com/embed/";
+        let vimeoURL = "https://player.vimeo.com/video/";	
+        let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
+        
+        const { playing, muted, loop } = this.state;
+        
+        return (
+            <React.Fragment>        
+            <div className={"embed-responsive embed-responsive-" + videoSize}>
+            <button style="width:100px; position:absolute; top:10%; left:50%; transform:translate(-10%,-50%); background:#c20430; color:#fff; font-weight:bold; z-index:50;" onClick={this.handlePlayPause}>{playing ? 'Pause' : 'Play'}</button>
+            <ReactPlayer
+                ref={this.ref}
+                url={videoSrc}
+                playing={playing}
+                loop={loop}
+                muted={muted}
+                width="100%"
+                height="100%"
+            />
+            </div>      
+            </React.Fragment>
+        )
+    }
 }
+
 HeroVideo.propTypes = {
-	playerID: PropTypes.string,
-	videoURL: PropTypes.string,
-	videoTranscript: PropTypes.string,
-	videoCC: PropTypes.string,
+    playerID: PropTypes.string,
+    videoURL: PropTypes.string,
+    videoTranscript: PropTypes.string,
+    videoCC: PropTypes.string,
     videoSize: PropTypes.string,
 }
 HeroVideo.defaultProps = {
-	playerID: ``,
-	videoURL: ``,
-	videoTranscript: ``,
-	videoCC: ``,
+    playerID: ``,
+    videoURL: ``,
+    videoTranscript: ``,
+    videoCC: ``,
     videoSize: `16by9`,
 }
 export default HeroVideo

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -61,7 +61,6 @@ class HeroVideo extends Component {
                     ref={this.ref}
                     className="react-player"
                     url={videoSrc}
-                    config={{ vimeo: { playerOptions:{portrait:true} } }}
                     playing={playing}
                     loop={loop}
                     muted={muted}

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
 import { contentExists } from '../utils/ug-utils';
+import '../styles/heroVideo.css';
 
 class HeroVideo extends Component {
     
@@ -35,7 +36,9 @@ class HeroVideo extends Component {
         return (
             <React.Fragment>        
             <div className={"embed-responsive embed-responsive-" + videoSize}>
-            <button style="width:100px; position:absolute; top:10%; left:50%; transform:translate(-10%,-50%); background:#c20430; color:#fff; font-weight:bold; z-index:50;" onClick={this.handlePlayPause}>{playing ? 'Pause' : 'Play'}</button>
+            <button className="hero-playPause" onClick={this.handlePlayPause}>
+                <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
+            </button>
             <ReactPlayer
                 ref={this.ref}
                 url={videoSrc}

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -41,16 +41,18 @@ class HeroVideo extends Component {
 
         const { playing, muted, loop, videoStatus, playPause } = this.state;
         
+        console.log(videoTranscript);
+        
         return (
             <React.Fragment>
             <div className={"hero-controls-" + aspectRatio + videoStatus}>
-                <button id="heroButton" className="hero-playPause" data-toggle="tooltip" data-placement="bottom" data-selector="true" title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
+                <button id="hero-playPause" data-toggle="tooltip" data-placement="bottom" data-selector="true" title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
                     <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
                     <span className="sr-only">{playing ? "Pause video" : "Play video"}</span>
                 </button>
                 {contentExists(videoTranscript) ? 
-                    <><a id="hero-transcript" href={videoTranscript} download>
-                        <i className="duotoneColors fad fa-file-download"></i>
+                    <><a id="hero-transcript" href={videoTranscript} download data-toggle="tooltip" data-placement="bottom" data-selector="true" title="Download transcript">
+                        <i className="duotoneColors fad fa-file-alt"></i>
                         <span className="sr-only">Download transcript</span>                        
                     </a></>
                 : ``}

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactPlayer from 'react-player';
+import PropTypes from 'prop-types';
+import { contentExists } from '../utils/ug-utils';
+
+function HeroVideo (props) {
+	let playerID = props.playerID;
+	let videoCC = props.videoCC;
+    let videoSize = props.videoSize;
+	let videoTranscript = props.videoTranscript;
+	let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
+	let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
+
+	let youtubeURL = "https://www.youtube.com/embed/";
+	let vimeoURL = "https://player.vimeo.com/video/";	
+	let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
+	
+	return (
+		<React.Fragment>        
+        <div style="max-width:100%; max-height:60rem;" className={"embed-responsive embed-responsive-" + videoSize}>
+        <ReactPlayer url={videoSrc}
+            playing
+            loop
+            muted
+            width="100%"
+            height="100%"
+        />
+        </div>      
+        </React.Fragment>
+	)
+}
+HeroVideo.propTypes = {
+	playerID: PropTypes.string,
+	videoURL: PropTypes.string,
+	videoTranscript: PropTypes.string,
+	videoCC: PropTypes.string,
+    videoSize: PropTypes.string,
+}
+HeroVideo.defaultProps = {
+	playerID: ``,
+	videoURL: ``,
+	videoTranscript: ``,
+	videoCC: ``,
+    videoSize: `16by9`,
+}
+export default HeroVideo

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -41,22 +41,20 @@ class HeroVideo extends Component {
 
         const { playing, muted, loop, videoStatus, playPause } = this.state;
         
-        console.log(videoTranscript);
-        
         return (
             <React.Fragment>
             <div className={"hero-controls-" + aspectRatio + videoStatus}>
-                <button id="hero-playPause" data-toggle="tooltip" data-placement="bottom" data-selector="true" title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
-                    <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
+                <button id="hero-playPause" aria-label={playing ? "Pause" : "Play"} title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
+                    <i aria-hidden="true" className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
                     <span className="sr-only">{playing ? "Pause video" : "Play video"}</span>
                 </button>
                 {contentExists(videoTranscript) ? 
-                    <><a id="hero-transcript" href={videoTranscript} download data-toggle="tooltip" data-placement="bottom" data-selector="true" title="Download transcript">
-                        <i className="duotoneColors fad fa-file-alt"></i>
+                    <><a id="hero-transcript" href={videoTranscript} download aria-label="Download transcript" title="Download transcript">
+                        <i aria-hidden="true" className="duotoneColors fad fa-file-alt"></i>
                         <span className="sr-only">Download transcript</span>                        
                     </a></>
                 : ``}
-                <i className="hero-thruster fas fa-spinner fa-spin"></i>
+                <i aria-label="Loading video" className="hero-thruster fas fa-spinner fa-spin"></i>
             </div>
             <div className={"embed-responsive embed-responsive-" + aspectRatio}>                
                 <ReactPlayer

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
-//import { contentExists } from '../utils/ug-utils';
 import '../styles/heroVideo.css';
 
 class HeroVideo extends Component {
@@ -11,8 +10,7 @@ class HeroVideo extends Component {
         muted: true,
         loop: true,
         videoStatus: " hero-loading",
-    }
-    
+    }    
     ref = player => {
         this.player = player
     }
@@ -25,10 +23,11 @@ class HeroVideo extends Component {
     }
     
     render() {
-        let playerID = this.props.playerID;
-        let videoCC = this.props.videoCC;
-        let videoSize = this.props.videoSize;
+
+        let videoCC = this.props.videoCC;        
         let videoTranscript = this.props.videoTranscript;
+        let videoWidth = this.props.videoWidth;
+        let videoHeight = this.props.videoHeight;
         let videoType = (this.props.videoURL.includes("youtube") || this.props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
         let videoID = (videoType === `youtube` ? this.props.videoURL.substr(this.props.videoURL.length - 11) : this.props.videoURL.substr(18));
 
@@ -36,17 +35,22 @@ class HeroVideo extends Component {
         let vimeoURL = "https://player.vimeo.com/video/";	
         let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
         
-        const { playing, muted, loop, videoStatus } = this.state;
+        let ratio = videoWidth / videoHeight;        
+        ratio = +ratio.toFixed(2);
+        const aspectRatio = (ratio === 2.34 ? "21by9" : "16by9");
+
+        const { playing, muted, loop, videoStatus, playPause } = this.state;
         
         return (
             <React.Fragment>
-            <div className={"hero-controls" + videoStatus}>
-                <button className="hero-playPause" onClick={this.handlePlayPause}>
+            <div className={"hero-controls-" + aspectRatio + videoStatus}>
+                <button id="heroButton" className="hero-playPause" data-toggle="tooltip" data-placement="bottom" data-selector="true" title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
                     <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
+                    <span className="sr-only">{playing ? "Pause" : "Play"}</span>
                 </button>
                 <i className="hero-thruster fas fa-spinner fa-spin"></i>
             </div>
-            <div className={"embed-responsive embed-responsive-" + videoSize}>                
+            <div className={"embed-responsive embed-responsive-" + aspectRatio}>                
                 <ReactPlayer
                     ref={this.ref}
                     className="react-player"
@@ -66,17 +70,17 @@ class HeroVideo extends Component {
 }
 
 HeroVideo.propTypes = {
-    playerID: PropTypes.string,
     videoURL: PropTypes.string,
     videoTranscript: PropTypes.string,
     videoCC: PropTypes.string,
-    videoSize: PropTypes.string,
+    videoWidth: PropTypes.number,
+    videoHeight: PropTypes.number,
 }
 HeroVideo.defaultProps = {
-    playerID: ``,
     videoURL: ``,
     videoTranscript: ``,
     videoCC: ``,
-    videoSize: `16by9`,
+    videoWidth: 16,
+    videoHeight: 9,
 }
 export default HeroVideo

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
-import { contentExists } from '../utils/ug-utils';
+//import { contentExists } from '../utils/ug-utils';
 import '../styles/heroVideo.css';
 
 class HeroVideo extends Component {
@@ -9,7 +9,8 @@ class HeroVideo extends Component {
     state = {
         playing: true,
         muted: true,
-        loop: true
+        loop: true,
+        videoStatus: " hero-loading",
     }
     
     ref = player => {
@@ -17,6 +18,10 @@ class HeroVideo extends Component {
     }
     handlePlayPause = () => {
         this.setState({ playing: !this.state.playing })
+    }
+    
+    handleStart = () => {
+        this.setState({ videoStatus: " hero-ready" })
     }
     
     render() {
@@ -31,23 +36,29 @@ class HeroVideo extends Component {
         let vimeoURL = "https://player.vimeo.com/video/";	
         let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
         
-        const { playing, muted, loop } = this.state;
+        const { playing, muted, loop, videoStatus } = this.state;
         
         return (
-            <React.Fragment>        
-            <div className={"embed-responsive embed-responsive-" + videoSize}>
-            <button className="hero-playPause" onClick={this.handlePlayPause}>
-                <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
-            </button>
-            <ReactPlayer
-                ref={this.ref}
-                url={videoSrc}
-                playing={playing}
-                loop={loop}
-                muted={muted}
-                width="100%"
-                height="100%"
-            />
+            <React.Fragment>
+            <div className={"hero-controls" + videoStatus}>
+                <button className="hero-playPause" onClick={this.handlePlayPause}>
+                    <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
+                </button>
+                <i className="hero-thruster fas fa-spinner fa-spin"></i>
+            </div>
+            <div className={"embed-responsive embed-responsive-" + videoSize}>                
+                <ReactPlayer
+                    ref={this.ref}
+                    className="react-player"
+                    url={videoSrc}
+                    config={{ vimeo: { playerOptions:{portrait:true} } }}
+                    playing={playing}
+                    loop={loop}
+                    muted={muted}
+                    width="100%"
+                    height="100%"
+                    onStart={this.handleStart}
+                />
             </div>      
             </React.Fragment>
         )

--- a/src/components/heroVideo.js
+++ b/src/components/heroVideo.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
+import { contentExists } from '../utils/ug-utils';
 import '../styles/heroVideo.css';
 
 class HeroVideo extends Component {
@@ -24,7 +25,6 @@ class HeroVideo extends Component {
     
     render() {
 
-        let videoCC = this.props.videoCC;        
         let videoTranscript = this.props.videoTranscript;
         let videoWidth = this.props.videoWidth;
         let videoHeight = this.props.videoHeight;
@@ -46,8 +46,14 @@ class HeroVideo extends Component {
             <div className={"hero-controls-" + aspectRatio + videoStatus}>
                 <button id="heroButton" className="hero-playPause" data-toggle="tooltip" data-placement="bottom" data-selector="true" title={playing ? "Pause" : "Play"} onClick={this.handlePlayPause}>
                     <i className={playing ? "duotoneColors fad fa-pause-circle" : "duotoneColors fad fa-play-circle"}></i>
-                    <span className="sr-only">{playing ? "Pause" : "Play"}</span>
+                    <span className="sr-only">{playing ? "Pause video" : "Play video"}</span>
                 </button>
+                {contentExists(videoTranscript) ? 
+                    <><a id="hero-transcript" href={videoTranscript} download>
+                        <i className="duotoneColors fad fa-file-download"></i>
+                        <span className="sr-only">Download transcript</span>                        
+                    </a></>
+                : ``}
                 <i className="hero-thruster fas fa-spinner fa-spin"></i>
             </div>
             <div className={"embed-responsive embed-responsive-" + aspectRatio}>                

--- a/src/components/mediaText.js
+++ b/src/components/mediaText.js
@@ -14,7 +14,7 @@ function MediaText (props) {
 	const mediaRelationships = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.relationships: ``);
 	
 	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
-	const imageAlt = (contentExists(props.widgetData.relationships.field_media_text_media.field_media_image) ? props.widgetData.relationships.field_media_text_media.field_media_image.alt : ``);
+	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
 	
 	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
 	const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);

--- a/src/components/video.js
+++ b/src/components/video.js
@@ -5,7 +5,6 @@ import { contentExists } from '../utils/ug-utils';
 function Video (props) {
 	let playerID = props.playerID;
 	let videoCC = props.videoCC;
-    let videoSize = props.videoSize;
 	let videoTranscript = props.videoTranscript;
 	let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
 	let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
@@ -16,10 +15,10 @@ function Video (props) {
 	
 	return (
 		<React.Fragment>		
-		
+		<div className="col-lg-6 col-md-12">
             <div id="video-embed">
                 <section name={videoType} className="ui-kit-section">
-                    <div style="max-width: 1400px; margin:0 auto;" className={"embed-responsive embed-responsive-" + videoSize}>
+                    <div className="embed-responsive embed-responsive-16by9">
                         <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls">
                             <source type={`video/` + videoType} src={videoSrc} />
 							{contentExists(videoTranscript) ? 
@@ -30,7 +29,7 @@ function Video (props) {
                     </div>
                 </section>
             </div>
-        
+        </div>
 		</React.Fragment>
 	)
 }
@@ -39,13 +38,11 @@ Video.propTypes = {
 	videoURL: PropTypes.string,
 	videoTranscript: PropTypes.string,
 	videoCC: PropTypes.string,
-    videoSize: PropTypes.string,
 }
 Video.defaultProps = {
 	playerID: ``,
 	videoURL: ``,
 	videoTranscript: ``,
 	videoCC: ``,
-    videoSize: `16by9`,
 }
 export default Video

--- a/src/components/video.js
+++ b/src/components/video.js
@@ -5,6 +5,7 @@ import { contentExists } from '../utils/ug-utils';
 function Video (props) {
 	let playerID = props.playerID;
 	let videoCC = props.videoCC;
+    let videoSize = props.videoSize;
 	let videoTranscript = props.videoTranscript;
 	let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
 	let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
@@ -15,10 +16,10 @@ function Video (props) {
 	
 	return (
 		<React.Fragment>		
-		<div className="col-lg-6 col-md-12">
+		
             <div id="video-embed">
                 <section name={videoType} className="ui-kit-section">
-                    <div className="embed-responsive embed-responsive-16by9">
+                    <div style="max-width: 1400px; margin:0 auto;" className={"embed-responsive embed-responsive-" + videoSize}>
                         <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls">
                             <source type={`video/` + videoType} src={videoSrc} />
 							{contentExists(videoTranscript) ? 
@@ -29,7 +30,7 @@ function Video (props) {
                     </div>
                 </section>
             </div>
-        </div>
+        
 		</React.Fragment>
 	)
 }
@@ -38,11 +39,13 @@ Video.propTypes = {
 	videoURL: PropTypes.string,
 	videoTranscript: PropTypes.string,
 	videoCC: PropTypes.string,
+    videoSize: PropTypes.string,
 }
 Video.defaultProps = {
 	playerID: ``,
 	videoURL: ``,
 	videoTranscript: ``,
 	videoCC: ``,
+    videoSize: `16by9`,
 }
 export default Video

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,21 +1,59 @@
 .hero-playPause {
 	background: none;
-	width:100px; 
-	position:absolute; 
-	top:10%; left:50%; 
-	transform:translate(-10%,-50%); 
-	font-weight:bold;
-	font-size: 7rem;
-	z-index:50;
+	height: 6rem;
+	width: 6rem;
 	border: none;
+	margin-top: 6rem; 
+	margin-left: 95%;
+	padding: 0;
+}
+.hero-playPause:focus {
+	outline: thin dotted #fff;
+	border-radius: 2rem;
+}
+.hero-playPause i {
+	font-size: 6rem;
+}
+.hero-controls {
+	position:absolute;
+	top:0; 
+	left:50%; 
+	transform:translateX(-50%); 
+	z-index:1; 
+	height:100%; 
+	aspect-ratio:21 / 9; 	
+}
+i.hero-thruster {
+	font-size: 8rem;
+	color: #fff;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 8rem;
+	height: 8rem;
+	transform: translate(-50%,-50%);
+}
+.hero-loading {
+	background: #000;
+}
+
+.hero-ready {
+	background: transparent !important;
+}
+.hero-ready i.hero-thruster {
+	display: none !important;
 }
 
 .duotoneColors {
-	--fa-primary-color: #fff;
+	--fa-primary-color: #ffc72a;
 	--fa-secondary-color: #c20430;
 	--fa-secondary-opacity: 1.0;
 }
 .duotoneColors:hover {
 	--fa-primary-color: #c20430;
-	--fa-secondary-color: #fff;	
+	--fa-secondary-color: #ffc72a;	
+}
+
+.react-player {
+	background: #000;
 }

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -23,6 +23,12 @@ a#hero-transcript {
 	text-align: center;
 }
 
+#rotator,
+.hero-controls-16by9,
+.hero-controls-21by9 {
+	max-height: 77rem;	
+}
+
 .hero-controls-16by9,
 .hero-controls-21by9 {
 	position: absolute;
@@ -30,11 +36,10 @@ a#hero-transcript {
 	left: 50%; 
 	transform: translateX(-50%); 
 	z-index: 1;
-	width: 100%;
-	max-height: 600px;		
+	width: 100%;	
 }
 .hero-controls-16by9 {
-	aspect-ratio: 16 / 9; 
+	aspect-ratio: 16 / 9;
 }
 .hero-controls-21by9 {
 	aspect-ratio: 21 / 9;
@@ -99,5 +104,13 @@ i.hero-thruster {
 		font-size: 4rem;
 		height: 4rem;
 		width: 4rem;
+	}
+}
+
+@media only screen and (max-height: 1080px) {
+	#rotator,
+	.hero-controls-16by9,
+	.hero-controls-21by9 {
+		max-height: 60rem;
 	}
 }

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -12,8 +12,7 @@ button#hero-playPause {
 	top: 4rem;
 }
 button#hero-playPause:focus {
-	outline: thin dotted #fff;
-	border-radius: 2rem;
+	outline: 0.1rem dotted #ffc72a;
 }
 button#hero-playPause i,
 a#hero-transcript i {

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,5 +1,5 @@
-button.hero-playPause,
-a.hero-transcript {
+button#hero-playPause,
+a#hero-transcript {
 	position: absolute;	
 	right: 3rem;
 	background: none;
@@ -8,21 +8,22 @@ a.hero-transcript {
 	width: 6rem;
 	padding: 0;
 }
-button.hero-playPause {
+button#hero-playPause {
 	top: 4rem;
 }
-button.hero-playPause:focus {
+button#hero-playPause:focus {
 	outline: thin dotted #fff;
 	border-radius: 2rem;
 }
-button.hero-playPause i {
+button#hero-playPause i {
 	font-size: 6rem;
 }
 
-a.hero-transcript {
-	top: 8rem;
+a#hero-transcript {
+	top: 12rem;
+	text-align: center;
 }
-a.hero-transcript i {
+a#hero-transcript i {
 	font-size: 6rem;
 }
 
@@ -80,13 +81,13 @@ i.hero-thruster {
 }
 
 @media only screen and (max-width: 768px) {
-	.hero-playPause {
+	button#hero-playPause {
 		top: 1.5rem;
 		right: 1.5rem;
 		height: 3rem;
 		width: 3rem;
 	}
-	.hero-playPause i {
+	button#hero-playPause i {
 		font-size: 3rem;
 	}
 	i.hero-thruster {

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,10 +1,11 @@
 .hero-playPause {
+	position: absolute;
+	top: 4rem;
+	right: 3rem;
 	background: none;
+	border: none;
 	height: 6rem;
 	width: 6rem;
-	border: none;
-	margin-top: 6rem; 
-	margin-left: 95%;
 	padding: 0;
 }
 .hero-playPause:focus {
@@ -15,13 +16,14 @@
 	font-size: 6rem;
 }
 .hero-controls {
-	position:absolute;
-	top:0; 
-	left:50%; 
-	transform:translateX(-50%); 
-	z-index:1; 
-	height:100%; 
-	aspect-ratio:21 / 9; 	
+	position: absolute;
+	top: 0; 
+	left: 50%; 
+	transform: translateX(-50%); 
+	z-index: 1;
+	width: 100%;
+	max-height: 600px; 
+	aspect-ratio: 21 / 9; 	
 }
 i.hero-thruster {
 	font-size: 8rem;
@@ -29,14 +31,13 @@ i.hero-thruster {
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	width: 8rem;
 	height: 8rem;
+	width: 8rem;	
 	transform: translate(-50%,-50%);
 }
 .hero-loading {
-	background: #000;
+	background: rgba(0, 0, 0, 0.5);
 }
-
 .hero-ready {
 	background: transparent !important;
 }
@@ -54,6 +55,19 @@ i.hero-thruster {
 	--fa-secondary-color: #ffc72a;	
 }
 
-.react-player {
-	background: #000;
+@media only screen and (max-width: 768px) {
+	.hero-playPause {
+		top: 1.5rem;
+		right: 1.5rem;
+		height: 3rem;
+		width: 3rem;
+	}
+	.hero-playPause i {
+		font-size: 3rem;
+	}
+	i.hero-thruster {
+		font-size: 4rem;
+		height: 4rem;
+		width: 4rem;
+	}
 }

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,4 +1,4 @@
-.hero-playPause {
+button.hero-playPause {
 	position: absolute;
 	top: 4rem;
 	right: 3rem;
@@ -15,34 +15,47 @@
 .hero-playPause i {
 	font-size: 6rem;
 }
-.hero-controls {
+.hero-controls-16by9,
+.hero-controls-21by9 {
 	position: absolute;
 	top: 0; 
 	left: 50%; 
 	transform: translateX(-50%); 
 	z-index: 1;
 	width: 100%;
-	max-height: 600px; 
-	aspect-ratio: 21 / 9; 	
+	max-height: 600px;		
+}
+.hero-controls-16by9 {
+	aspect-ratio: 16 / 9; 
+}
+.hero-controls-21by9 {
+	aspect-ratio: 21 / 9;
 }
 i.hero-thruster {
 	font-size: 8rem;
 	color: #fff;
 	position: absolute;
-	top: 50%;
-	left: 50%;
+	top: 45%;
+	left: 48%;
 	height: 8rem;
 	width: 8rem;	
-	transform: translate(-50%,-50%);
+	transform: translate(-45%,-48%);
+	display: block;
 }
 .hero-loading {
 	background: rgba(0, 0, 0, 0.5);
+}
+.hero-loading button.hero-playPause {
+	display: none;
 }
 .hero-ready {
 	background: transparent !important;
 }
 .hero-ready i.hero-thruster {
 	display: none !important;
+}
+.hero-ready button.hero-playPause {
+	display: block;
 }
 
 .duotoneColors {

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -54,7 +54,8 @@ i.hero-thruster {
 .hero-loading {
 	background: rgba(0, 0, 0, 0.5);
 }
-.hero-loading button.hero-playPause {
+.hero-loading button#hero-playPause,
+.hero-loading a#hero-transcript {
 	display: none;
 }
 .hero-ready {
@@ -63,7 +64,8 @@ i.hero-thruster {
 .hero-ready i.hero-thruster {
 	display: none !important;
 }
-.hero-ready button.hero-playPause {
+.hero-ready button#hero-playPause,
+.hero-ready a#hero-transcript {
 	display: block;
 }
 

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,6 +1,6 @@
-button.hero-playPause {
-	position: absolute;
-	top: 4rem;
+button.hero-playPause,
+a.hero-transcript {
+	position: absolute;	
 	right: 3rem;
 	background: none;
 	border: none;
@@ -8,13 +8,24 @@ button.hero-playPause {
 	width: 6rem;
 	padding: 0;
 }
-.hero-playPause:focus {
+button.hero-playPause {
+	top: 4rem;
+}
+button.hero-playPause:focus {
 	outline: thin dotted #fff;
 	border-radius: 2rem;
 }
-.hero-playPause i {
+button.hero-playPause i {
 	font-size: 6rem;
 }
+
+a.hero-transcript {
+	top: 8rem;
+}
+a.hero-transcript i {
+	font-size: 6rem;
+}
+
 .hero-controls-16by9,
 .hero-controls-21by9 {
 	position: absolute;

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -15,16 +15,13 @@ button#hero-playPause:focus {
 	outline: thin dotted #fff;
 	border-radius: 2rem;
 }
-button#hero-playPause i {
+button#hero-playPause i,
+a#hero-transcript i {
 	font-size: 6rem;
 }
-
 a#hero-transcript {
 	top: 12rem;
 	text-align: center;
-}
-a#hero-transcript i {
-	font-size: 6rem;
 }
 
 .hero-controls-16by9,
@@ -71,23 +68,30 @@ i.hero-thruster {
 }
 
 .duotoneColors {
-	--fa-primary-color: #ffc72a;
+	--fa-primary-color: #fff;
 	--fa-secondary-color: #c20430;
 	--fa-secondary-opacity: 1.0;
 }
 .duotoneColors:hover {
 	--fa-primary-color: #c20430;
-	--fa-secondary-color: #ffc72a;	
+	--fa-secondary-color: #fff;	
 }
 
 @media only screen and (max-width: 768px) {
-	button#hero-playPause {
-		top: 1.5rem;
+	button#hero-playPause,
+	a#hero-transcript {
 		right: 1.5rem;
 		height: 3rem;
 		width: 3rem;
 	}
-	button#hero-playPause i {
+	button#hero-playPause {
+		top: 1.5rem;
+	}
+	a#hero-transcript {	
+		top: 5.5rem;
+	}
+	button#hero-playPause i,
+	a#hero-transcript i	{
 		font-size: 3rem;
 	}
 	i.hero-thruster {

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -1,0 +1,21 @@
+.hero-playPause {
+	background: none;
+	width:100px; 
+	position:absolute; 
+	top:10%; left:50%; 
+	transform:translate(-10%,-50%); 
+	font-weight:bold;
+	font-size: 7rem;
+	z-index:50;
+	border: none;
+}
+
+.duotoneColors {
+	--fa-primary-color: #fff;
+	--fa-secondary-color: #c20430;
+	--fa-secondary-opacity: 1.0;
+}
+.duotoneColors:hover {
+	--fa-primary-color: #c20430;
+	--fa-secondary-color: #fff;	
+}

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -403,7 +403,7 @@ function prepareVariantHeading (variantData) {
       { /**** Header and Title ****/ }
       <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
         {contentExists(videoData) ?
-            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" />
+            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoWidth={videoData.field_video_width} videoHeight={videoData.field_video_height} />
             :
             <Hero imgData={heroImage} />
         }
@@ -975,6 +975,8 @@ export const query = graphql`query ($id: String) {
         node {
           drupal_id
           field_media_oembed_video
+          field_video_width
+          field_video_height
           name
         }
       }

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -19,6 +19,8 @@ import Svg from 'react-inlinesvg';
 import Tags from '../components/tags';
 import Testimonials from '../components/testimonial';
 import Variants from '../components/variants';
+//import Video from '../components/video'; 
+import HeroVideo from '../components/heroVideo'; 
 import { contentExists, contentIsNullOrEmpty, sortLastModifiedDates } from '../utils/ug-utils';
 import { graphql } from 'gatsby';
 import { useIconData } from '../utils/fetch-icon';
@@ -345,6 +347,7 @@ function prepareVariantHeading (variantData) {
     let tagData;
     let testimonialData;
     let variantData;
+    let videoData;
 
     // set data
     if (data.careers.edges[0] !== undefined) { careerData = data.careers.edges; }
@@ -358,8 +361,10 @@ function prepareVariantHeading (variantData) {
     if (data.testimonials.edges[0] !== undefined) { testimonialData = data.testimonials.edges; }
     if (data.images.edges !== undefined) { imageData = data.images.edges; }
     if (data.imagesTagged.edges !== undefined) { imageTaggedData = data.imagesTagged.edges; }
+    if (data.videos.edges[0] !== undefined) { videoData = data.videos.edges[0].node; }
     
     const heroImage = (contentExists(imageData) ? imageData : (contentExists(imageTaggedData) ? imageTaggedData : null));
+    console.log(videoData);
 
     // set program details
     const nodeID = progData.drupal_internal__nid;
@@ -396,8 +401,13 @@ function prepareVariantHeading (variantData) {
       <Seo title={title} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
 
       { /**** Header and Title ****/ }
-      <div className={!contentExists(heroImage) && "no-thumb"} id="rotator">
-        <Hero imgData={heroImage} />
+      <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
+          {contentExists(videoData) ?
+            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" />
+
+            :
+            <Hero imgData={heroImage} />
+          }
         <div className="container ft-container">
           <h1 className="fancy-title">{title}</h1>
         </div>
@@ -959,6 +969,17 @@ export const query = graphql`query ($id: String) {
       }
     }
   }
+  videos: allMediaRemoteVideo(
+      filter: {relationships: {node__program: {elemMatch: {relationships: {field_program_acronym: {id: {eq: $id}}}}}}}
+    ) {
+      edges {
+        node {
+          drupal_id
+          field_media_oembed_video
+          name
+        }
+      }
+    }
   news: allNodeArticle(
     limit: 4
     sort: {fields: created}

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -7,9 +7,10 @@ import Breadcrumbs from '../components/breadcrumbs';
 import CallToAction from '../components/callToAction';
 import Careers from '../components/careers';
 import Courses from '../components/courses';
+import CustomFooter from '../components/customFooter';
 import Degrees from '../components/degrees';
 import Employers from '../components/employers';
-import CustomFooter from '../components/customFooter';
+import HeroVideo from '../components/heroVideo';
 import NavTabs from '../components/navTabs';
 import NavTabHeading from '../components/navTabHeading';
 import NavTabContent from '../components/navTabContent';
@@ -19,8 +20,7 @@ import Svg from 'react-inlinesvg';
 import Tags from '../components/tags';
 import Testimonials from '../components/testimonial';
 import Variants from '../components/variants';
-import Video from '../components/video'; 
-import HeroVideo from '../components/heroVideo'; 
+ 
 import { contentExists, contentIsNullOrEmpty, sortLastModifiedDates } from '../utils/ug-utils';
 import { graphql } from 'gatsby';
 import { useIconData } from '../utils/fetch-icon';
@@ -397,17 +397,16 @@ function prepareVariantHeading (variantData) {
           class: 'program'
         }}
       />
-      <Helmet><script type="text/javascript" defer src="/uog-scripts-dist.js"></script></Helmet>
+      <Helmet><script type="text/javascript" defer src="https://www.uoguelph.ca/js/uog-scripts-dist.js"></script></Helmet>
       <Seo title={title} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
 
       { /**** Header and Title ****/ }
       <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
-          {contentExists(videoData) ?
+        {contentExists(videoData) ?
             <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" />
-                /* <Video playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" /> */
             :
             <Hero imgData={heroImage} />
-          }
+        }
         <div className="container ft-container">
           <h1 className="fancy-title">{title}</h1>
         </div>

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -403,7 +403,7 @@ function prepareVariantHeading (variantData) {
       { /**** Header and Title ****/ }
       <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
         {contentExists(videoData) ?
-            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoWidth={videoData.field_video_width} videoHeight={videoData.field_video_height} />
+            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoWidth={videoData.field_video_width} videoHeight={videoData.field_video_height} videoTranscript={videoData.relationships.field_media_file.localFile.publicURL} />
             :
             <Hero imgData={heroImage} />
         }
@@ -978,6 +978,13 @@ export const query = graphql`query ($id: String) {
           field_video_width
           field_video_height
           name
+          relationships {
+            field_media_file {
+              localFile {
+                publicURL
+              }
+            }
+          }
         }
       }
     }

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -364,7 +364,6 @@ function prepareVariantHeading (variantData) {
     if (data.videos.edges[0] !== undefined) { videoData = data.videos.edges[0].node; }
     
     const heroImage = (contentExists(imageData) ? imageData : (contentExists(imageTaggedData) ? imageTaggedData : null));
-    console.log(videoData);
 
     // set program details
     const nodeID = progData.drupal_internal__nid;

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -403,7 +403,7 @@ function prepareVariantHeading (variantData) {
       { /**** Header and Title ****/ }
       <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
         {contentExists(videoData) ?
-            <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoWidth={videoData.field_video_width} videoHeight={videoData.field_video_height} videoTranscript={videoData.relationships.field_media_file.localFile.publicURL} />
+            <HeroVideo videoURL={videoData.field_media_oembed_video} videoWidth={videoData.field_video_width} videoHeight={videoData.field_video_height} videoTranscript={contentExists(videoData.relationships.field_media_file) ? videoData.relationships.field_media_file.localFile.publicURL : ``} />
             :
             <Hero imgData={heroImage} />
         }

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -19,7 +19,7 @@ import Svg from 'react-inlinesvg';
 import Tags from '../components/tags';
 import Testimonials from '../components/testimonial';
 import Variants from '../components/variants';
-//import Video from '../components/video'; 
+import Video from '../components/video'; 
 import HeroVideo from '../components/heroVideo'; 
 import { contentExists, contentIsNullOrEmpty, sortLastModifiedDates } from '../utils/ug-utils';
 import { graphql } from 'gatsby';
@@ -397,14 +397,14 @@ function prepareVariantHeading (variantData) {
           class: 'program'
         }}
       />
-      <Helmet><script type="text/javascript" defer src="https://www.uoguelph.ca/js/uog-scripts-dist.js"></script></Helmet>
+      <Helmet><script type="text/javascript" defer src="/uog-scripts-dist.js"></script></Helmet>
       <Seo title={title} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
 
       { /**** Header and Title ****/ }
       <div className={!contentExists(heroImage) && !contentExists(videoData) && "no-thumb"} id="rotator">
           {contentExists(videoData) ?
             <HeroVideo playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" />
-
+                /* <Video playerID={videoData.drupal_id} videoURL={videoData.field_media_oembed_video} videoSize="21by9" /> */
             :
             <Hero imgData={heroImage} />
           }


### PR DESCRIPTION
# Summary of Changes

## Frontend
- Feature branch URL: https://tqtest.gatsbyjs.io/
- New plugin: [react-player](https://github.com/cookpete/react-player)
- New component: [heroVideo.js](https://github.com/ccswbs/gus/pull/42/files#diff-b5e9d505fc92fc31d61e5165fd5a3e098139c5c687df4efc285e462a9c8b786a)
- New stylesheet: [heroVideo.css](https://github.com/ccswbs/gus/pull/42/files#diff-55017c62566ceca3c9bdb5f5c97bd3141a873461ab88094bb46c32e8803d91b3)
- Program page checks if Hero component is an image or video 
- Null checks for video width and height added to `gatsby-node.js`

## Backend
- Multidev URL: https://herovid-chug.pantheonsite.io/
- Video width and height fields added to Remote Video media type
- Remote Video added as option for Program page feature area
- Improvements to Media views (filter by video url and tags)
- Removed obsolete Video custom content type

## Test Plan
- Go to https://tqtest.gatsbyjs.io/programs/associate-diploma-in-testing-technology-and-ridiculously-long-program-names-that-wrap
- Verify presence of placeholder until video loads 
- Verify play/pause button works and is keyboard-accessible
- Resize window and verify video scales in a responsive manner
- Go to https://tqtest.gatsbyjs.io/programs/master-of-data-science
- Verify Download Transcript icon/link appears and works
- Go to https://herovid-chug.pantheonsite.io/
- Create a new remote video
- Verify the width and height fields are automatically populated after you click "Save"
- Edit an existing program, preferably one that doesn't already have a feature image
- Click "Add media"
- Click the "Remote video" tab
- Type _vimeo_ in the "Video URL" field and verify only Vimeo videos are returned
- Type _you_ in the same field and verify YouTube videos are returned instead