### PR TITLE
Fix remote video relationships schema

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -187,6 +187,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type media__remote_videoRelationships implements Node {
       field_media_file: file__file @link(from: "field_media_file___NODE")
       field_video_cc: file__file @link(from: "field_video_cc___NODE")
+      node__program: [node__program] @link(from: "node__program___NODE")
     }
     
     type MenuItems implements Node {


### PR DESCRIPTION
To resolve `Field "nodeprogram" is not defined by type "mediaremote_videoRelationshipsFilterInput".` error