### PR TITLE
fix layout for list

### DIFF
--- a/src/components/linksOuter.js
+++ b/src/components/linksOuter.js
@@ -13,11 +13,10 @@ function LinksOuter (props) {
     let Heading = setHeadingLevel(props.headingLevel);
 	if (contentExists(props.children)) {
 		return (<div className={setBackGroundClass}>
-                    <div>
-                    <Heading>{props.heading}</Heading>
-                    <p>{props.description}</p>
+                    <div className="col-md-12">
+                    {contentExists(props.heading) && <Heading>{props.heading}</Heading>}
+                    {contentExists(props.description) && <p>{props.description}</p>}
                         <LinksParent extraClasses={setExtraClasses}>
-                         
                             {props.children}
                         </LinksParent>
                     </div>


### PR DESCRIPTION
This is a fix for layout of links widget when the items are displayed in a list - was bunching up in first column of 12. Now takes up the full width of the space available.  

Also an AODA fix do not display a blank header (and paragraph) element when no data is entered. 
Note both of these are using the same drupal back end (https://api.liveugconthub.uoguelph.dev/

https://ugconthub.gtsb.io/chancellor (page as it is)
https://gusfixlist.gatsbyjs.io/chancellor (page as it is fixed)

does not affect pages that use a grid of images for the links widget:
Both of these pages are identical - with a heading for the links widget showing.

https://ugconthub.gtsb.io/welcome-home
https://gusfixlist.gatsbyjs.io/welcome-home

Only change was done to the linksOuter.js file (adding two null checks and one class to a div element).