### PR TITLE
Add UG spinner code and fix other video issues

### DIFF
--- a/src/components/mediaText.js
+++ b/src/components/mediaText.js
@@ -16,15 +16,16 @@ function MediaText (props) {
 	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
 	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
 	
+    const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
 	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
 	const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);
 	const videoCC = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_video_cc) ? mediaRelationships.field_video_cc.localFile.publicURL : ``);
-	
+    
 	return <>	
 
 			<section className={props.colClass}>
 			{contentExists(videoURL) ?
-			<Video playerID={props.widgetData.drupal_id} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
+			<Video playerID={playerID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
 			: ``}
 			{contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
 			</section>

--- a/src/components/video.js
+++ b/src/components/video.js
@@ -3,46 +3,51 @@ import PropTypes from 'prop-types';
 import { contentExists } from '../utils/ug-utils';
 
 function Video (props) {
-	let playerID = props.playerID;
-	let videoCC = props.videoCC;
-	let videoTranscript = props.videoTranscript;
-	let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
-	let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
+    let playerID = props.playerID;
+    let videoCC = props.videoCC;
+    let videoTranscript = props.videoTranscript;
+    let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
+    let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
 
-	let youtubeURL = "https://www.youtube.com/embed/";
-	let vimeoURL = "https://player.vimeo.com/video/";	
-	let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
-	
-	return (
-		<React.Fragment>		
-		<div className="col-lg-6 col-md-12">
+    let youtubeURL = "https://www.youtube.com/embed/";
+    let vimeoURL = "https://player.vimeo.com/video/";	
+    let videoSrc = (videoType === `youtube` ? youtubeURL + videoID : vimeoURL + videoID);
+    
+    return (
+        <React.Fragment>
+        <div className="col-lg-6 col-md-12">
             <div id="video-embed">
                 <section name={videoType} className="ui-kit-section">
                     <div className="embed-responsive embed-responsive-16by9">
+                        <div className="d-flex justify-content-center">
+                            <div className="spinner-grow text-yellow" role="status">
+                                <span className="sr-only">Loading...</span>
+                            </div>
+                        </div>
                         <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls">
                             <source type={`video/` + videoType} src={videoSrc} />
-							{contentExists(videoTranscript) ? 
-							<><track className="caption-input" label="English" kind="subtitles" srclang="en" src={videoCC} default="true" />
-							<link className="transcript-input" rel="transcript" label="English" kind="descriptions" srclang="en" src={videoTranscript} default="true" /></>
-							: ``}							
+                            {contentExists(videoTranscript) ? 
+                            <><track className="caption-input" label="English" kind="subtitles" srclang="en" src={videoCC} default="true" />
+                            <link className="transcript-input" rel="transcript" label="English" kind="descriptions" srclang="en" src={videoTranscript} default="true" /></>
+                            : ``}
                         </video>
                     </div>
                 </section>
             </div>
         </div>
-		</React.Fragment>
-	)
+        </React.Fragment>
+    )
 }
 Video.propTypes = {
-	playerID: PropTypes.string,
-	videoURL: PropTypes.string,
-	videoTranscript: PropTypes.string,
-	videoCC: PropTypes.string,
+    playerID: PropTypes.string,
+    videoURL: PropTypes.string,
+    videoTranscript: PropTypes.string,
+    videoCC: PropTypes.string,
 }
 Video.defaultProps = {
-	playerID: ``,
-	videoURL: ``,
-	videoTranscript: ``,
-	videoCC: ``,
+    playerID: ``,
+    videoURL: ``,
+    videoTranscript: ``,
+    videoCC: ``,
 }
 export default Video

--- a/src/styles/heroVideo.css
+++ b/src/styles/heroVideo.css
@@ -28,6 +28,9 @@ a#hero-transcript {
 .hero-controls-21by9 {
 	max-height: 77rem;	
 }
+#rotator .embed-responsive {
+	background: transparent !important;
+}
 
 .hero-controls-16by9,
 .hero-controls-21by9 {


### PR DESCRIPTION
# Summary of changes

## Frontend

- Add UG spinner code to `video.js`
- Fix playerID variable code in `mediaText.js`
- Override white background (introduced by UG spinner code) in `heroVideo.css`

## Test plan

1. Go to https://tqtest.gatsbyjs.io/spinner-test and confirm the grey background with yellow pulsing dot show up until the video loads
2. View source code of above page and confirm `<video>` element has a unique value for `id`
3. Go to https://tqtest.gatsbyjs.io/programs/bcomm-test and verify hero area has dark-grey patterned background