### PR TITLE
Page sitemap

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -893,7 +893,10 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
             const config = require('./gatsby-config');
             const menuNames = config.siteMetadata.menus;            
             menuNames.forEach(element => createSitemap(menus, element, aliases));
-    }
+        }
+        
+        // generate page listing (sitemap)
+        createSitePageList(helpers);
     }
 }
 
@@ -966,6 +969,20 @@ function createContentTypeAlias(nodePath) {
         alias = `/` + slugify(node.title);
     }
     return alias;
+}
+
+// list of pages for SE site
+function createSitePageList(helpers) {
+
+    helpers.createPage({
+      path: `/sitemap-se/`,
+      component: path.resolve(`./src/templates/sitemap-page.js`),
+      context: {
+         searchfilt: `/studentexperience/`,
+      },
+    })
+
+    return;
 }
 
 // Source: https://medium.com/@mhagemann/the-ultimate-way-to-slugify-a-url-string-in-javascript-b8e4a0d849e1

--- a/src/templates/sitemap-page.js
+++ b/src/templates/sitemap-page.js
@@ -1,0 +1,37 @@
+import { graphql, Link } from 'gatsby';
+import Layout from '../components/layout';
+import React from 'react';
+
+const SitePage = ({pageContext, data }) => {
+  return (
+    <Layout>
+        <div className="container page-container">
+            <h1>Sitemap</h1>
+            
+            <h2>Pages for {pageContext.searchfilt}</h2>
+            <ul>
+                {data.allNodePage.edges.map((edge, index) => (
+                    <li key={index}><Link to={edge.node.path.alias}>{edge.node.title}</Link></li>
+                ))}
+            </ul>
+
+        </div>
+    </Layout>
+}
+export default SitePage
+
+export const query = graphql`
+    query filterAllPage($searchfilt: String) {
+        allNodePage(filter: {path: {alias: {regex: $searchfilt }}}) {
+        edges {
+          node {
+            title
+            drupal_id
+            path {
+              alias
+            }
+          }
+        }
+      }
+    }
+`

--- a/src/templates/sitemap-page.js
+++ b/src/templates/sitemap-page.js
@@ -7,7 +7,8 @@ const SitePage = ({pageContext, data }) => {
     <Layout>
         <div className="container page-container">
             <h1>Sitemap</h1>
-            
+            <p>The University of Guelph, and everyone who studies here, explores here, teaches here a
+nd works here, is committed to one simple purpose: To Improve Life.</p>
             <h2>Pages for {pageContext.searchfilt}</h2>
             <ul>
                 {data.allNodePage.edges.map((edge, index) => (
@@ -17,7 +18,9 @@ const SitePage = ({pageContext, data }) => {
 
         </div>
     </Layout>
+  )
 }
+
 export default SitePage
 
 export const query = graphql`


### PR DESCRIPTION
To create a page that links to all the Student Experience pages

FRONTEND (Gatsby): 

- sitempage-page.js - template page that filters the list of pages using a value passed in from gatsby-node.js 
- gatsby-node.js - added function that creates the listing page using specific values for student experience

BACKEND (Drupal): live
- no changes

TESTING: 
The page https://ugconthub-pagesitemap.gtsb.io/sitemap-se , should display all pages that have an alias that includes the keyword "studentexperience"