### PR TITLE
accordian Widget configuration

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -139,21 +139,28 @@ exports.createSchemaCustomization = ({ actions }) => {
       format: String
       summary: String
     }
-    type FieldAccordionBlockText {
+    type FieldAccordionBlockText implements Node {
       processed: String
       value: String
       format: String
       summary: String
     }
-    type FieldAccordionBlockTitle {
+    type FieldAccordionBlockTitle implements Node {
       processed: String
       value: String
       format: String
       summary: String
     }
-    type FieldAccordionBlockElement {
-      field_accordion_block_text: FieldAccordionBlockText
-      field_accordion_block_title: FieldAccordionBlockTitle
+    type FieldAccordionBlockElement implements Node {
+      field_accordion_block_text: FieldAccordionBlockText @link(from:" field_accordion_block_text___NODE")
+      field_accordion_block_title: FieldAccordionBlockTitle @link(from:" field_accordion_block_title___NODE")
+    }
+    type paragraph__accordion_section implements Node {
+      drupal_id: String
+      relationships: paragraph__accordion_sectionRelationship
+    }
+    type paragraph__accordion_sectionRelationship implements Node {
+      field_accordion_block_elements: FieldAccordionBlockElement @link(from:"field_accordion_block_elements___NODE")
     }
     type FieldFormattedTitle {
       processed: String
@@ -444,20 +451,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       field_lead_paratext: BodyField
       relationships: node__lead_paragraphRelationships
     }
-
-
-
-    
-    type paragraph__accordion_section implements Node {
-      drupal_id: String
-      relationships: paragraph__accordion_sectionRelationship
-    }
-    type paragraph__accordion_sectionRelationship implements Node {
-      field_accordion_block_element: FieldAccordionBlockElement
-    }
-
-
-
     type node__lead_paragraphRelationships implements Node {
       field_lead_para_hero: media__image @link(from: "field_lead_para_hero___NODE")
       field_section_column: taxonomy_term__section_columns @link(from: "field_section_column___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -139,7 +139,22 @@ exports.createSchemaCustomization = ({ actions }) => {
       format: String
       summary: String
     }
-  
+    type FieldAccordionBlockText {
+      processed: String
+      value: String
+      format: String
+      summary: String
+    }
+    type FieldAccordionBlockTitle {
+      processed: String
+      value: String
+      format: String
+      summary: String
+    }
+    type FieldAccordionBlockElement {
+      field_accordion_block_text: FieldAccordionBlockText
+      field_accordion_block_title: FieldAccordionBlockTitle
+    }
     type FieldFormattedTitle {
       processed: String
       value: String
@@ -429,6 +444,19 @@ exports.createSchemaCustomization = ({ actions }) => {
       field_lead_paratext: BodyField
       relationships: node__lead_paragraphRelationships
     }
+
+
+
+    
+    type paragraph__accordion_section implements Node {
+      drupal_id: String
+      relationships: paragraph__accordion_sectionRelationship
+    }
+    type paragraph__accordion_sectionRelationship implements Node {
+      field_accordion_block_element: FieldAccordionBlockElement
+    }
+
+
 
     type node__lead_paragraphRelationships implements Node {
       field_lead_para_hero: media__image @link(from: "field_lead_para_hero___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -151,18 +151,6 @@ exports.createSchemaCustomization = ({ actions }) => {
       format: String
       summary: String
     }
-    type paragraph__accordion_block implements Node {
-      drupal_id: String
-      field_accordion_block_text: FieldAccordionBlockText
-      field_accordion_block_title: FieldAccordionBlockTitle
-    }
-    type paragraph__accordion_section implements Node {
-      drupal_id: String
-      relationships: paragraph__accordion_sectionRelationships
-    }
-    type paragraph__accordion_sectionRelationships implements Node {
-      field_accordion_block_elements: [paragraph__accordion_block] @link(from: "field_accordion_block_elements___NODE")
-    }
     type FieldFormattedTitle {
       processed: String
       value: String
@@ -414,7 +402,19 @@ exports.createSchemaCustomization = ({ actions }) => {
     type node__testimonialRelationships {
       field_hero_image: media__image @link(from: "field_hero_image___NODE")
       field_tags: [relatedTaxonomyUnion] @link(from: "field_tags___NODE")
-    }   
+    }  
+    type paragraph__accordion_block implements Node {
+      drupal_id: String
+      field_accordion_block_text: FieldAccordionBlockText
+      field_accordion_block_title: FieldAccordionBlockTitle
+    }
+    type paragraph__accordion_section implements Node {
+      drupal_id: String
+      relationships: paragraph__accordion_sectionRelationships
+    }
+    type paragraph__accordion_sectionRelationships implements Node {
+      field_accordion_block_elements: [paragraph__accordion_block] @link(from: "field_accordion_block_elements___NODE")
+    } 
     type paragraph__button_widget implements Node {
       drupal_id: String
       field_button_link: FieldLink

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -139,28 +139,29 @@ exports.createSchemaCustomization = ({ actions }) => {
       format: String
       summary: String
     }
-    type FieldAccordionBlockText implements Node {
+    type FieldAccordionBlockText {
       processed: String
       value: String
       format: String
       summary: String
     }
-    type FieldAccordionBlockTitle implements Node {
+    type FieldAccordionBlockTitle {
       processed: String
       value: String
       format: String
       summary: String
     }
-    type FieldAccordionBlockElement implements Node {
-      field_accordion_block_text: FieldAccordionBlockText @link(from:" field_accordion_block_text___NODE")
-      field_accordion_block_title: FieldAccordionBlockTitle @link(from:" field_accordion_block_title___NODE")
+    type paragraph__accordion_block implements Node {
+      drupal_id: String
+      field_accordion_block_text: FieldAccordionBlockText
+      field_accordion_block_title: FieldAccordionBlockTitle
     }
     type paragraph__accordion_section implements Node {
       drupal_id: String
-      relationships: paragraph__accordion_sectionRelationship
+      relationships: paragraph__accordion_sectionRelationships
     }
-    type paragraph__accordion_sectionRelationship implements Node {
-      field_accordion_block_elements: [FieldAccordionBlockElement] @link(from:"field_accordion_block_elements___NODE")
+    type paragraph__accordion_sectionRelationships implements Node {
+      field_accordion_block_elements: [paragraph__accordion_block] @link(from: "field_accordion_block_elements___NODE")
     }
     type FieldFormattedTitle {
       processed: String

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -114,6 +114,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       | paragraph__stats_widget
       | paragraph__section_tabs
       | paragraph__tab_content
+      | paragraph__accordion_section
 
     union widgetSectionParagraphUnion =
       paragraph__call_to_action

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -160,7 +160,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       relationships: paragraph__accordion_sectionRelationship
     }
     type paragraph__accordion_sectionRelationship implements Node {
-      field_accordion_block_elements: FieldAccordionBlockElement @link(from:"field_accordion_block_elements___NODE")
+      field_accordion_block_elements: [FieldAccordionBlockElement] @link(from:"field_accordion_block_elements___NODE")
     }
     type FieldFormattedTitle {
       processed: String

--- a/package-lock.json
+++ b/package-lock.json
@@ -16749,11 +16749,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -20,7 +20,6 @@ import { contentExists } from '../utils/ug-utils';
 //
 
 function Widgets (props) {
-
 if (contentExists(props.pageData) && props.pageData.length !== 0) {
     return (props.pageData.map((widgetData,i) => {
         if (widgetData.__typename==="paragraph__links_widget") {
@@ -59,10 +58,7 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
             return (<>
 				{contentExists(sectionTitle) === true && <h2>{sectionTitle}</h2>}
 				<div className={widgetData.field_section_classes}>
-                    
-                        <SectionWidgets pageData={widgetData.relationships.field_section_content}/>
-              
-					
+                    <SectionWidgets pageData={widgetData.relationships.field_section_content}/>	
                 </div>
 			</>);
         }
@@ -78,7 +74,26 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
 		else if (widgetData.__typename==="paragraph__section_tabs") {
             		return( <PageTabs pageData={widgetData} />);
 		}
-
+        else if (widgetData.__typename==="paragraph__accordion_section") {
+            return(
+                widgetData.relationships.field_accordion_block_elements.map((accordionData,j) => {
+                    return( <>
+                        <div class="panel-group panel-group-lists collapse in show" id={"accordionWidget"+widgetData.drupal_id}>
+                            <div class="panel">
+                                <div class="panel-heading">
+                                    <h4 class="panel-title">
+                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widgetData.drupal_id} href={"#collapse"+j} class="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
+                                    </h4>
+                                </div>
+                                <div id={"collapse"+j} class="panel-collapse collapse in">
+                                    <div class="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
+                                </div>
+                            </div>
+                        </div>
+                    </>);
+                } )
+            );  
+}
 		return null;
     }
     ))}

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -75,6 +75,7 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
             		return( <PageTabs pageData={widgetData} />);
 		}
         else if (widgetData.__typename==="paragraph__accordion_section") {
+            console.log(widgetData)
             return(
                 widgetData.relationships.field_accordion_block_elements.map((accordionData,j) => {
                     return( <>

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -75,7 +75,6 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
             		return( <PageTabs pageData={widgetData} />);
 		}
         else if (widgetData.__typename==="paragraph__accordion_section") {
-            console.log(widgetData)
             return(
                 widgetData.relationships.field_accordion_block_elements.map((accordionData,j) => {
                     return( <>

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -82,10 +82,10 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
                             <div class="panel">
                                 <div class="panel-heading">
                                     <h4 class="panel-title">
-                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widgetData.drupal_id} href={"#collapse"+j} class="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
+                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widgetData.drupal_id} href={"#collapse"+j+widgetData.drupal_id} class="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
                                     </h4>
                                 </div>
-                                <div id={"collapse"+j} class="panel-collapse collapse in">
+                                <div id={"collapse"+j+widgetData.drupal_id} class="panel-collapse collapse in">
                                     <div class="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
                                 </div>
                             </div>

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -97,6 +97,19 @@ export const query = graphql`query ($id: String) {
                 }
               }
             }
+            ... on paragraph__accordion_section {
+              drupal_id
+              relationships {
+                field_accordion_block_elements {
+                  field_accordion_block_title {
+                    processed
+                  }
+                  field_accordion_block_text {
+                    processed
+                  }
+                }
+              }
+            }
             ... on paragraph__lead_paragraph {
               id
               field_lead_paratext {

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -101,6 +101,7 @@ export const query = graphql`query ($id: String) {
               drupal_id
               relationships {
                 field_accordion_block_elements {
+                  drupal_id
                   field_accordion_block_title {
                     processed
                   }


### PR DESCRIPTION
SUMMARY:

This feature will add an accordion widget to the widget field. This will allow for the addition of accordion elements to be added to a page. Each accordion can have as many expanding points as needed.  

BACKEND (Drupal): https://accordion-chug.pantheonsite.io/
- Paragraph Accordion Section 
  - which only has one field that is a reference to the Accordion Block paragraph
- Paragraph Accordion Block
  - Two fields, both of which are formatted so that basic html can be used 
    -  Title
    -  Text
 
FRONTEND (Gatsby): gus/accordion branch
- gatsby-node.js - add paragraph__accordion_section to widgetParagraphUnion
- widget.js - add code to display paragraph 
- basic-page.js - added to query to include the accordion paragraphs from drupal

TESTING (Gatsby Cloud): 
https://www.gatsbyjs.com/dashboard/2e86c058-a370-4898-ae51-9698cd178e8d/sites/4d03c6f6-9271-4faf-8419-e36460e489d7/deploys
https://gusaccordion.gatsbyjs.io/

Existing page
- https://gusaccordion.gatsbyjs.io/masters-of-biomedical-sciences-mbs the accordions on that page are done by the widget.
New page
- Add new basic page and add an accordion widget with at least one accordion block. 
- trigger build on gatsby cloud and examine page to ensure the accordion widget is working.
- edit widget and add <strong> </strong> around the title field and re-trigger build to ensure the formatting works. 
- Add a second accordion to the page to ensure that multiple accordion widgets can work on one page.
-re-trigger build

