### PR TITLE
Proglist

### DIFF
--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -78,15 +78,15 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
             return(
                 widgetData.relationships.field_accordion_block_elements.map((accordionData,j) => {
                     return( <>
-                        <div class="panel-group panel-group-lists collapse in show" id={"accordionWidget"+widgetData.drupal_id}>
-                            <div class="panel">
-                                <div class="panel-heading">
-                                    <h4 class="panel-title">
-                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widgetData.drupal_id} href={"#collapse"+j+widgetData.drupal_id} class="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
+                        <div className="panel-group panel-group-lists collapse in show" id={"accordionWidget"+widgetData.drupal_id}>
+                            <div className="panel">
+                                <div className="panel-heading">
+                                    <h4 className="panel-title">
+                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widgetData.drupal_id} href={"#collapse"+j+widgetData.drupal_id} className="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
                                     </h4>
                                 </div>
-                                <div id={"collapse"+j+widgetData.drupal_id} class="panel-collapse collapse in">
-                                    <div class="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
+                                <div id={"collapse"+j+widgetData.drupal_id} className="panel-collapse collapse in">
+                                    <div className="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
                                 </div>
                             </div>
                         </div>

--- a/src/pages/programs.js
+++ b/src/pages/programs.js
@@ -15,7 +15,7 @@ const ProgramsPage = ({ data }) => (
                 <div id="program-list" className="row row-cols-1 row-cols-md-4 g-4 mb-5">
                   {console.log(data)}
                     {data.allNodeProgram.edges.map((edge, index) => (
-                      <div className="col">
+                      edge.node.status=== true && <div className="col">
                           <div className="card h-100">
                             <h2 key={index}><a className="stretched-link" href={edge.node.path.alias}>{edge.node.title}</a></h2>
                             <div>{edge.node.relationships.field_program_acronym.name}</div>

--- a/src/pages/programs.js
+++ b/src/pages/programs.js
@@ -13,13 +13,11 @@ const ProgramsPage = ({ data }) => (
                 <p>The University of Guelph is a comprehensive university offering a wide variety of programs and specialties. From general arts, commerce and science degrees, to unique programs in indigenous environmental science, veterinary technology, bio-resource management and one health. Explore everything your future can be at the University of Guelph.</p>     
                 <br/>
                 <div id="program-list" className="row row-cols-1 row-cols-md-4 g-4 mb-5">
-                  {console.log(data)}
                     {data.allNodeProgram.edges.map((edge, index) => (
                       edge.node.status=== true && <div className="col">
                           <div className="card h-100">
                             <h2 key={index}><a className="stretched-link" href={edge.node.path.alias}>{edge.node.title}</a></h2>
                             <div>{edge.node.relationships.field_program_acronym.name}</div>
-                            <div>status={edge.node.status=== true && <span>true</span>}</div>
                           </div>
                       </div>
                     ))}

--- a/src/pages/programs.js
+++ b/src/pages/programs.js
@@ -9,13 +9,17 @@ const ProgramsPage = ({ data }) => (
         <Seo title="Program List" description={[`Univeristy of Guelph Programs`]} />
         <div className="container page-container">
             <div id="content" className="site-content">
-                <h1>Programs</h1>            
+                <h1>Programs</h1>       
+                <p>The University of Guelph is a comprehensive university offering a wide variety of programs and specialties. From general arts, commerce and science degrees, to unique programs in indigenous environmental science, veterinary technology, bio-resource management and one health. Explore everything your future can be at the University of Guelph.</p>     
+                <br/>
                 <div id="program-list" className="row row-cols-1 row-cols-md-4 g-4 mb-5">
+                  {console.log(data)}
                     {data.allNodeProgram.edges.map((edge, index) => (
                       <div className="col">
                           <div className="card h-100">
                             <h2 key={index}><a className="stretched-link" href={edge.node.path.alias}>{edge.node.title}</a></h2>
                             <div>{edge.node.relationships.field_program_acronym.name}</div>
+                            <div>status={edge.node.status=== true && <span>true</span>}</div>
                           </div>
                       </div>
                     ))}
@@ -38,6 +42,7 @@ export const query = graphql`
             path {
               alias
             }
+            status
             relationships {
               field_program_acronym {
                 name

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,10 @@
     flex: 1;
 }
 
+html {
+    scroll-padding-top: 10rem;
+}
+
 @media (max-width: 575.98px){
     .main-container {
         padding-top: 0 !important;


### PR DESCRIPTION
SUMMARY:
- Added a paragraph blurb to the page /programlist
- Added logic to only display published programs
- Fixed code in widgets.js (changed class to className)
- Added css to add padding to scrolling for anchors - so that content is not hidden behind the sticky header. 

BACKEND (Drupal):
No updates

FRONTEND (Gatsby):

- page programlist.js 
  - add logic so that if status is true display program
  - added the text below the title and above the program list
- widgets.js - updated class to className 
- global.css - added html { scroll-padding-top: 10rem; } - picked 10rem as it seemed most pleasing can change if we need to. 

TESTING (Gatsby Cloud):

The new page - https://gusproglist.gatsbyjs.io/programs/ compared to the old page - https://livechugendpoint.azureedge.net/programs/
- blurb has been added 
- two less programs (ones that are not published) check https://livechugendpoint.azureedge.net/ or https://gusproglist.gatsbyjs.io to see current programs that are published or not published. 

Scroll Padding for anchors (with spacing):
https://gusproglist.gatsbyjs.io/ovc-alumni-association-awards#young
https://gusproglist.gatsbyjs.io/ovc-alumni-association-awards#volunteer
https://gusproglist.gatsbyjs.io/ovc-alumni-association-awards#distinguished

(without padding): 
https://preview-ugconthub.gtsb.io/ovc-alumni-association-awards#young
https://preview-ugconthub.gtsb.io/ovc-alumni-association-awards#volunteer
https://preview-ugconthub.gtsb.io/ovc-alumni-association-awards#distinguished