### PR TITLE
Refactor tabs to fix duplicate ID bug (FP 453934)

### DIFF
--- a/src/components/pageTabs.js
+++ b/src/components/pageTabs.js
@@ -1,74 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { contentExists, contentIsNullOrEmpty, setHeadingLevel } from '../utils/ug-utils.js';
+import { contentExists } from '../utils/ug-utils.js';
 import NavTabs from '../components/navTabs';
 import NavTabHeading from '../components/navTabHeading';
 import NavTabContent from '../components/navTabContent';
-import '../styles/list.css';
 
 function renderTabInfo (pageData) {
-	let activeValue = true;
-	let activeTabExists = false;
-	let checkIfContentAvailable = false;
-	let navTabHeadings = [];
-	let navTabContent = [];
-	
+    
+    let activeValue = true;
+    let navTabHeadings = [];
+    let navTabContent = [];    
 
-	if (!contentIsNullOrEmpty(pageData) ) {
+    if (contentExists(pageData)) {
 
-		let tabID = "";
-		activeTabExists = true;
-		checkIfContentAvailable = true;
+        let tabID = "";
 
-		for (let i = 0; i < pageData.relationships.field_tabs.length; i++) {
-			tabID = "pills-" + i;
+        for (let i = 0; i < pageData.relationships.field_tabs.length; i++) {
+            tabID = "pills-" + pageData.relationships.field_tabs[i].drupal_id;
 
-			if (i > 0) activeValue = false;
+            if (i > 0) activeValue = false;
 
-		navTabHeadings.push(<NavTabHeading key={`navTabHeading-` + i}
-			   active={activeValue}
-	   		   heading={pageData.relationships.field_tabs[i].field_tab_title}
-	   		   controls={tabID}
-				/>);
+            navTabHeadings.push(<NavTabHeading key={`navTabHeading-` + i}
+                active={activeValue}
+                heading={pageData.relationships.field_tabs[i].field_tab_title}
+                controls={tabID}
+            />);
 
-		navTabContent.push(<NavTabContent key={`navTabContent-` + i}
-				  active={activeValue}
-				  id={tabID}
-				  content=<div dangerouslySetInnerHTML={{ __html: pageData.relationships.field_tabs[i].field_tab_body.processed }} />
-				/>);
-		}
-	}
+            navTabContent.push(<NavTabContent key={`navTabContent-` + i}
+                active={activeValue}
+                id={tabID}
+                content=<div dangerouslySetInnerHTML={{ __html: pageData.relationships.field_tabs[i].field_tab_body.processed }} />
+            />);
+        }
+        return (
+        <React.Fragment>
+            <NavTabs headings={
+                navTabHeadings.map((heading) => {
+                    return heading;
+                    })
+                }>
+                {navTabContent.map((content) => {
+                    return content;
 
-	if (checkIfContentAvailable === true) {
-		return <React.Fragment>
-			<NavTabs headings={
-				navTabHeadings.map((heading) => {
-					return heading;
-					})
-				}>
-				{navTabContent.map((content) => {
-					return content;
-
-				})}
-			</NavTabs>
-			</React.Fragment>
-	}
-
-	return null;
+                })}
+            </NavTabs>
+        </React.Fragment>
+        )
+    }
+    return null;
 }
 
 function pageTabs (props) {
 
-
-	if(contentExists(props.pageData) && props.pageData.length !== 0){
-	   return (<div className="col-md-12 content-area">
-		 {renderTabInfo(props.pageData)}
-                   </div>
-            )
-
-	} else {
-		return null;
-	}
+    if (contentExists(props.pageData) && props.pageData.length !== 0) {        
+        return (
+            <div className="col-md-12 content-area">
+                {renderTabInfo(props.pageData)}
+           </div>
+        )
+    } else {
+        return null;
+    }
 }
 
 pageTabs.propTypes = {

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -143,17 +143,18 @@ export const query = graphql`query ($id: String, $nid: String) {
                 }
               }
             }
-        ... on paragraph__section_tabs {
+            ... on paragraph__section_tabs {
               id
               relationships {
                 field_tabs {
+                  drupal_id
                   field_tab_title
                   field_tab_body {
                     processed
                   }
                 }
               }
-        }
+            }
             ... on paragraph__links_widget {
               drupal_id
               field_link_items_title


### PR DESCRIPTION
# Summary of Changes

This PR is to resolve FP 453934 opened by Student Experience. No backend changes were necessary.

- Add `drupal_id` to GraphQL tabs widget query in `basic-page.js`
- Use `drupal_id` for `tabID` in `pageTabs.js` to ensure each tab ID is unique
- Clean up and refactor `pageTabs.js` code
- Remove unneeded variables and stylesheet

# Test Plan

Compare https://ugconthub-tabfix.gtsb.io/studentexperience/intlstudent/quarantine with https://www.uoguelph.ca/studentexperience/intlstudent/quarantine - on the live site, tab content fails to change because of duplicate tab IDs. On the PR build site, each tab should work properly

