### PR TITLE
Picfix

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -485,9 +485,10 @@ exports.createSchemaCustomization = ({ actions }) => {
       field_link_image: media__image @link(from: "field_link_image___NODE")
     }
     type paragraph__media_text implements Node {
-      field_media_text_title: String
-      field_media_text_desc: BodyField
-      field_media_text_links: [FieldLink]     
+      field_media_image_size: String
+      field_media_text_desc: BodyField      
+      field_media_text_title: String      
+      field_media_text_links: [FieldLink]    
       relationships: paragraph__media_textRelationships
     }
     type paragraph__media_textRelationships implements Node {

--- a/src/components/mediaText.js
+++ b/src/components/mediaText.js
@@ -8,40 +8,64 @@ import { contentExists } from '../utils/ug-utils';
 
 function MediaText (props) {
 
-	const mediaTitle = (contentExists(props.widgetData.field_media_text_title) ? '<h3>' + props.widgetData.field_media_text_title + '</h3>': ``);
+	const mediaTitle = (contentExists(props.widgetData.field_media_text_title) ? props.widgetData.field_media_text_title : ``);
 	const mediaDescription = (contentExists(props.widgetData.field_media_text_desc) ? props.widgetData.field_media_text_desc.processed: ``);
 	const mediaLinks = props.widgetData.field_media_text_links;	
 	const mediaRelationships = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.relationships: ``);
 	
 	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
 	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
-	
+    const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_image_size) ? props.widgetData.field_image_size : ``);
+    
     const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
 	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
 	const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);
 	const videoCC = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_video_cc) ? mediaRelationships.field_video_cc.localFile.publicURL : ``);
     
+    let mediaCol;
+    let textCol;
+    
+    if (contentExists(imageSize)) {
+        switch(imageSize) {
+            case "small":
+                mediaCol = "col-md-3";
+                textCol = "col-md-9";
+            break;
+            case "medium":
+                mediaCol = "col-md-4";
+                textCol = "col-md-8";
+            break;
+            case "large":
+                mediaCol = "col-md-6";
+                textCol = "col-md-6";
+            break;
+        }        
+    } else {
+        mediaCol = props.colClass;
+        textCol = props.colClass;
+    }
+    
 	return <>	
 
-			<section className={props.colClass}>
+        <section className={mediaCol}>
 			{contentExists(videoURL) ?
 			<Video playerID={playerID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
 			: ``}
 			{contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
-			</section>
-			<section className={props.colClass}>
-				<div dangerouslySetInnerHTML={{ __html: mediaTitle}} />
-				<div dangerouslySetInnerHTML={{ __html: mediaDescription}} />
-				{contentExists(props.widgetData.relationships.field_button_section) === true &&<SectionButtons pageData={props.widgetData.relationships.field_button_section} />}
-				{contentExists(props.widgetData.relationships.field_button_section) === false && <div>{mediaLinks.map(mediaLink => {
-					return ( 
-					<React.Fragment>
-						{(mediaLink.uri.includes("http"))? <><a className="btn btn-outline-info" href={mediaLink.url}>{mediaLink.title}</a> </> :
-						<Link to={mediaLink.url} className="btn btn-outline-info" >{mediaLink.title}</Link>}
-					</React.Fragment>)
-					
-				})}</div>}
-			</section>
+        </section>
+        <section className={textCol}>
+            <h3 className="mt-md-0">{mediaTitle}</h3>
+            <div dangerouslySetInnerHTML={{ __html: mediaDescription}} />
+            {contentExists(props.widgetData.relationships.field_button_section) === true && <SectionButtons pageData={props.widgetData.relationships.field_button_section} />}
+            {contentExists(props.widgetData.relationships.field_button_section) === false && <div>{mediaLinks.map(mediaLink => {
+                return ( 
+                <React.Fragment>
+                    {(mediaLink.uri.includes("http"))? <><a className="btn btn-outline-info" href={mediaLink.url}>{mediaLink.title}</a> </> :
+                    <Link to={mediaLink.url} className="btn btn-outline-info" >{mediaLink.title}</Link>}
+                </React.Fragment>)
+                
+            })}</div>}
+        </section>
 		
 	</>;
 }

--- a/src/components/mediaText.js
+++ b/src/components/mediaText.js
@@ -15,7 +15,7 @@ function MediaText (props) {
 	
 	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
 	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
-    const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_image_size) ? props.widgetData.field_image_size : ``);
+    const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_media_image_size) ? props.widgetData.field_media_image_size : ``);
     
     const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
 	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);

--- a/src/components/mediaText.js
+++ b/src/components/mediaText.js
@@ -39,6 +39,10 @@ function MediaText (props) {
                 mediaCol = "col-md-6";
                 textCol = "col-md-6";
             break;
+            default:
+                mediaCol = "col-md-6";
+                textCol = "col-md-6";
+            break;
         }        
     } else {
         mediaCol = props.colClass;
@@ -54,7 +58,7 @@ function MediaText (props) {
 			{contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
         </section>
         <section className={textCol}>
-            <h3 className="mt-md-0">{mediaTitle}</h3>
+            {contentExists(props.headingClass) ? <h3 className={props.headingClass}>{mediaTitle}</h3> : <h3>{mediaTitle}</h3>}
             <div dangerouslySetInnerHTML={{ __html: mediaDescription}} />
             {contentExists(props.widgetData.relationships.field_button_section) === true && <SectionButtons pageData={props.widgetData.relationships.field_button_section} />}
             {contentExists(props.widgetData.relationships.field_button_section) === false && <div>{mediaLinks.map(mediaLink => {
@@ -73,10 +77,12 @@ function MediaText (props) {
 MediaText.propTypes = {
     widgetData: PropTypes.object,
 	colClass: PropTypes.string,
+    headingClass: PropTypes.string,
 }
 MediaText.defaultProps = {
     widgetData: null,
 	colClass: `col-md-6`,
+    headingClass: ``,
 }
 
 export default MediaText

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -66,7 +66,7 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
 		   return <div className="row mt-5"><MediaText headingClass="mt-md-0" widgetData={widgetData} /></div>
 		}
         else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
-            return <div className="container content-area" dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 
+            return <div dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 
         }
 		else if (widgetData.__typename==="paragraph__stats_widget") {
 			return <StatsWidget statsWidgetData={widgetData} />			

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -63,7 +63,7 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
 			</>);
         }
 		else if (widgetData.__typename==="paragraph__media_text") {
-		   return <div className="row site-content"><MediaText widgetData={widgetData} /></div>
+		   return <div className="row"><MediaText headingClass="mt-md-0" widgetData={widgetData} /></div>
 		}
         else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
             return <div className="container content-area" dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 

--- a/src/components/widgets.js
+++ b/src/components/widgets.js
@@ -63,7 +63,7 @@ if (contentExists(props.pageData) && props.pageData.length !== 0) {
 			</>);
         }
 		else if (widgetData.__typename==="paragraph__media_text") {
-		   return <div className="row"><MediaText headingClass="mt-md-0" widgetData={widgetData} /></div>
+		   return <div className="row mt-5"><MediaText headingClass="mt-md-0" widgetData={widgetData} /></div>
 		}
         else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
             return <div className="container content-area" dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,14 +35,14 @@ const IndexPage = ({ data }) => {
             <h1>Gatsby UG Starter Theme</h1>
             <p>The University of Guelph, and everyone who studies here, explores here, teaches here and works here, is committed to one simple purpose: To Improve Life.</p>
             <h2>Pages</h2>
-            <ul>
+            <ul className="two-col-md">
                 {pubPages.map((page) => (
                     <li key={page.node.drupal_id}><Link to={page.node.path.alias}>{page.node.title}</Link></li>
                 ))}
             </ul>
 
             <h2>Programs</h2>
-            <ul>
+            <ul className="two-col-md">
                 {pubPrograms.map((program) => (
                     <li key={program.node.drupal_id}><Link to={program.node.path.alias}>{program.node.title}</Link></li>
                 ))}
@@ -50,13 +50,13 @@ const IndexPage = ({ data }) => {
             
             <h2>Unpublished Content</h2>
             <h3>Pages</h3>
-            <ul>
+            <ul className="two-col-md">
                 {unpubPages.map((page) => (
                     <li key={page.node.drupal_id}><Link to={page.node.path.alias}>{page.node.title}</Link></li>
                 ))}
             </ul>
             <h3>Programs</h3>
-            <ul>
+            <ul className="two-col-md">
                 {unpubPrograms.map((program) => (
                     <li key={program.node.drupal_id}><Link to={program.node.path.alias}>{program.node.title}</Link></li>
                 ))}

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -422,6 +422,7 @@ export const query = graphql`query ($id: String, $nid: String) {
               }
             }
             ... on paragraph__media_text {
+              field_image_size
               field_media_text_title
               field_media_text_desc {
                 processed

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -422,7 +422,7 @@ export const query = graphql`query ($id: String, $nid: String) {
               }
             }
             ... on paragraph__media_text {
-              field_image_size
+              field_media_image_size
               field_media_text_title
               field_media_text_desc {
                 processed


### PR DESCRIPTION
# Summary of Changes

Provide content editors with the ability to display images at different sizes in the Media and Text widget (currently the image and text block default to equal widths only)

## Frontend

- Additional variables added to `mediaText.js`to account for image size and text column size
- Logic added to assign different Bootstrap 5 column classes depending on size selected
- Image Size field added to schema in `gatsby-node.js`
- Add utility class `two-col-md` to content listings in `index.js`
- General code refactoring and cleanup 

## Backend

- `Image Size` selection field added to Media and Text paragraph type
- `Video` removed from Media selection options (leaving `Image` and `Remote video`)

# Test Plan

- Go to https://picfix-chug.pantheonsite.io/
- Open basic page https://picfix-chug.pantheonsite.io/chancellor/chancellor-selection-committee for editing
- Edit one of the Media and Text widgets
- Verify the `Image Size` drop-down appears beneath `Media`
- Choose `Small`
- Save the page
- Go to https://www.gatsbyjs.com/dashboard/2e86c058-a370-4898-ae51-9698cd178e8d/sites/e1480ab1-9d0f-4dcb-9fda-75347c74c1c9/deploys and trigger a build
- Go to https://tqtest.gatsbyjs.io/chancellor/chancellor-selection-committee and verify the image whose size you changed displays correctly
- Repeat the above steps for additional Image Size options (i.e. `Medium` and `Large`)
