### PR TITLE
Basicfooter

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -815,11 +815,14 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         if (result.data.pages !== undefined) {
             const pages = result.data.pages.edges;
             pages.forEach(( { node }, index) => {
+              console.log(node.relationships.field_tags)
+              const fieldTags = JSON.parse(JSON.stringify(node.relationships.field_tags));
+              console.log(fieldTags);
                 aliases[node.drupal_internal__nid] = processPage(
                     node, 
                     node.id,
                     node.drupal_internal__nid,
-                    node.relationships.field_tags.id,
+                    fieldTags,
                     node.path, 
                     pageTemplate, 
                     helpers

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -811,14 +811,11 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         if (result.data.pages !== undefined) {
             const pages = result.data.pages.edges;
             pages.forEach(( { node }, index) => {
-              console.log(node.fields.tags);
-              const fieldTags = node.fields.tags;
-              console.log(fieldTags);
                 aliases[node.drupal_internal__nid] = processPage(
                     node, 
                     node.id,
                     node.drupal_internal__nid,
-                    fieldTags,
+                    node.fields.tags,
                     node.path, 
                     pageTemplate, 
                     helpers

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -750,12 +750,8 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
             drupal_id
             drupal_internal__nid
             title
-            relationships {
-              field_tags {
-                ... on taxonomy_term__units {
-                  id
-                }
-              }
+            fields {
+              tags
             }
             path {
               alias
@@ -815,8 +811,8 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         if (result.data.pages !== undefined) {
             const pages = result.data.pages.edges;
             pages.forEach(( { node }, index) => {
-              console.log(node.relationships.field_tags)
-              const fieldTags = JSON.parse(JSON.stringify(node.relationships.field_tags));
+              console.log(node.fields.tags)
+              const fieldTags = node.fields.tags;
               console.log(fieldTags);
                 aliases[node.drupal_internal__nid] = processPage(
                     node, 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,7 +17,7 @@
 
   OTHER Instructions
   - For the path alias, you will also need to:
-    - Add "node__contenttype.fields.alias": `PathAlias`, to the mapping in gatsby-config.js
+    - Add "(filter: {relationships: {node__page: {elemMatch: {id: {eq: $id}}}}})_contenttype.fields.alias": `PathAlias`, to the mapping in gatsby-config.js
     - Update exports.onCreateNode
   - Use THREE underscores when referencing nodes that do not exist yet (i.e. ___NODE)
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,9 +16,6 @@
      - "alias" under fields maps the generated alias to the query
 
   OTHER Instructions
-  - For the path alias, you will also need to:
-    - Add "(filter: {relationships: {node__page: {elemMatch: {id: {eq: $id}}}}})_contenttype.fields.alias": `PathAlias`, to the mapping in gatsby-config.js
-    - Update exports.onCreateNode
   - Use THREE underscores when referencing nodes that do not exist yet (i.e. ___NODE)
 
   Excellent Reading Material:

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -750,6 +750,13 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
             drupal_id
             drupal_internal__nid
             title
+            relationships {
+              field_tags {
+                ... on taxonomy_term__units {
+                  id
+                }
+              }
+            }
             path {
               alias
             }
@@ -812,6 +819,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
                     node, 
                     node.id,
                     node.drupal_internal__nid,
+                    node.relationships.field_tags.id,
                     node.path, 
                     pageTemplate, 
                     helpers
@@ -841,6 +849,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
                     node,
                     node.relationships.field_program_acronym.id,
                     node.drupal_internal__nid,
+                    null,
                     node.path, 
                     programTemplate, 
                     helpers
@@ -850,7 +859,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
     }
 }
 
-function processPage(node, contextID, nodeNid, nodePath, template, helpers) {
+function processPage(node, contextID, nodeNid, tagID, nodePath, template, helpers) {
     let alias = createContentTypeAlias(nodePath);
 
     helpers.createPage({
@@ -859,6 +868,7 @@ function processPage(node, contextID, nodeNid, nodePath, template, helpers) {
       context: {
         id: contextID,
         nid: `entity:node/` + nodeNid,
+        tid: tagID,
       },
     })
 

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -68,7 +68,9 @@ const BasicPage = ({data}) => {
 
 export default BasicPage;
 
-export const query = graphql`query ($id: String, $nid: String, $tid:[String] ) {
+export const query = graphql
+
+`query ($id: String, $nid: String, $tid: [String]) {
   pages: allNodePage(filter: {id: {eq: $id}}) {
     edges {
       node {
@@ -537,12 +539,15 @@ export const query = graphql`query ($id: String, $nid: String, $tid:[String] ) {
       }
     }
   }
-  footer: allNodeCustomFooter (filter: {fields: {tags: {in: [$tid]}}}){
+  footer: allNodeCustomFooter (filter: {fields: {tags: {in: $tid}}}){
     edges {
       node {
         drupal_id
         body {
           processed
+        }
+        fields {
+          tags
         }
         relationships {
           field_tags {

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -68,7 +68,7 @@ const BasicPage = ({data}) => {
 
 export default BasicPage;
 
-export const query = graphql`query ($id: String, $nid: String, $tid: String) {
+export const query = graphql`query ($id: String, $nid: String, $tid:[String] ) {
   pages: allNodePage(filter: {id: {eq: $id}}) {
     edges {
       node {

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -68,7 +68,7 @@ const BasicPage = ({data}) => {
 
 export default BasicPage;
 
-export const query = graphql`query ($id: String, $nid: String) {
+export const query = graphql`query ($id: String, $nid: String, $tid: String) {
   pages: allNodePage(filter: {id: {eq: $id}}) {
     edges {
       node {
@@ -537,7 +537,7 @@ export const query = graphql`query ($id: String, $nid: String) {
       }
     }
   }
-  footer: allNodeCustomFooter {
+  footer: allNodeCustomFooter (filter: {fields: {tags: {in: [$tid]}}}){
     edges {
       node {
         drupal_id
@@ -547,7 +547,7 @@ export const query = graphql`query ($id: String, $nid: String) {
         relationships {
           field_tags {
             __typename
-            ... on TaxonomyInterface {
+            ... on taxonomy_term__units {
               drupal_id
               id
               name

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -15,7 +15,7 @@ const BasicPage = ({data}) => {
     const nodeID = pageData.drupal_internal__nid;
     const title = pageData.title;
     const imageData = data.images.edges;
-    let footerData;
+    const footerData = data.footer.edges;
     const ogDescription = (contentExists(pageData.field_metatags) ? pageData.field_metatags.og_description : null);
     const ogImage = (contentExists(imageData) ? imageData[0].node.relationships.field_media_image.localFile.publicURL : null);
     const ogImageAlt = (contentExists(imageData) ? imageData[0].node.field_media_image.alt : null);
@@ -57,6 +57,7 @@ const BasicPage = ({data}) => {
                     </section>
                 </div>
             </div>
+            {console.log(data.footer.edges)}
             {console.log(footerData)}
             {contentExists(footerData) && footerData.length !== 0 &&
         <CustomFooter footerData={footerData[0]} />}
@@ -536,7 +537,7 @@ export const query = graphql`query ($id: String, $nid: String) {
       }
     }
   }
-  footer: allNodeCustomFooter(filter: {fields: {tags: {in: [$id]}}}) {
+  footer: allNodeCustomFooter {
     edges {
       node {
         drupal_id

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -57,8 +57,6 @@ const BasicPage = ({data}) => {
                     </section>
                 </div>
             </div>
-            {console.log(data.footer.edges)}
-            {console.log(footerData)}
             {contentExists(footerData) && footerData.length !== 0 &&
         <CustomFooter footerData={footerData[0]} />}
         </Layout>

--- a/src/templates/basic-page.js
+++ b/src/templates/basic-page.js
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import Seo from '../components/seo';
 import Hero from '../components/hero'; 
 import Breadcrumbs from '../components/breadcrumbs';
+import CustomFooter from '../components/customFooter';
 import Widgets from '../components/widgets'
 import { graphql } from 'gatsby';
 import { contentExists } from '../utils/ug-utils';
@@ -14,6 +15,7 @@ const BasicPage = ({data}) => {
     const nodeID = pageData.drupal_internal__nid;
     const title = pageData.title;
     const imageData = data.images.edges;
+    let footerData;
     const ogDescription = (contentExists(pageData.field_metatags) ? pageData.field_metatags.og_description : null);
     const ogImage = (contentExists(imageData) ? imageData[0].node.relationships.field_media_image.localFile.publicURL : null);
     const ogImageAlt = (contentExists(imageData) ? imageData[0].node.field_media_image.alt : null);
@@ -55,6 +57,9 @@ const BasicPage = ({data}) => {
                     </section>
                 </div>
             </div>
+            {console.log(footerData)}
+            {contentExists(footerData) && footerData.length !== 0 &&
+        <CustomFooter footerData={footerData[0]} />}
         </Layout>
     )
     
@@ -522,7 +527,227 @@ export const query = graphql`query ($id: String, $nid: String) {
           field_tags {
             __typename
             ... on TaxonomyInterface {
+              drupal_id
+              id
               name
+            }
+          }
+        }
+      }
+    }
+  }
+  footer: allNodeCustomFooter(filter: {fields: {tags: {in: [$id]}}}) {
+    edges {
+      node {
+        drupal_id
+        body {
+          processed
+        }
+        relationships {
+          field_tags {
+            __typename
+            ... on TaxonomyInterface {
+              drupal_id
+              id
+              name
+            }
+          }
+          field_footer_logo {
+            field_media_image {
+              alt
+            }
+            relationships {
+              field_media_image {
+                localFile {
+                  publicURL
+                  childImageSharp {
+                    gatsbyImageData(width: 400, placeholder: BLURRED, layout: CONSTRAINED)
+                  }
+                }
+              }
+            }
+          }
+          field_widgets {
+            __typename
+            ... on paragraph__call_to_action {
+              id
+              field_cta_title
+              field_cta_description
+              field_cta_primary_link {
+                title
+                uri
+              }
+            }
+            ... on paragraph__lead_paragraph {
+              id
+              field_lead_paratext {
+                value
+              }
+            }
+            ... on paragraph__links_widget {
+              drupal_id
+              field_link_items_title
+              field_link_items_description
+              relationships {
+                field_link_items {
+                  drupal_id
+                  field_link_description
+                  field_link_url {
+                    title
+                    uri
+                  }
+                  relationships {
+                    field_link_image {
+                      relationships {
+                        field_media_image {
+                          localFile {
+                            publicURL
+                            childImageSharp {
+                              resize(width: 400, height: 300, cropFocus: CENTER) {
+                                src
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ... on paragraph__section {
+              drupal_id
+              field_section_title
+              field_section_classes
+              relationships {
+                field_section_content {
+                  __typename
+                  ... on paragraph__call_to_action {
+                    id
+                    field_cta_title
+                    field_cta_description
+                    field_cta_primary_link {
+                      title
+                      uri
+                    }
+                  }
+                  ... on paragraph__links_widget {
+                    drupal_id
+                    field_link_items_title
+                    field_link_items_description
+                    relationships {
+                      field_link_items {
+                        drupal_id
+                        field_link_description
+                        field_link_url {
+                          title
+                          uri
+                        }
+                        relationships {
+                          field_link_image {
+                            relationships {
+                              field_media_image {
+                                localFile {
+                                  publicURL
+                                  childImageSharp {
+                                    resize(width: 400, height: 300, cropFocus: CENTER) {
+                                      src
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  ... on paragraph__media_text {
+                    field_media_text_title
+                    field_media_text_desc {
+                      processed
+                    }
+                    field_media_text_links {
+                      title
+                      uri
+                    }
+                    relationships {
+                      field_media_text_media {
+                        ... on media__image {
+                          name
+                          field_media_image {
+                            alt
+                          }
+                          relationships {
+                            field_media_image {
+                              localFile {
+                                publicURL
+                                childImageSharp {
+                                  gatsbyImageData(width: 800, placeholder: BLURRED, layout: CONSTRAINED)
+                                }
+                              }
+                            }
+                          }
+                        }
+                        ... on media__remote_video {
+                          drupal_id
+                          name
+                          field_media_oembed_video
+                          relationships {
+                            field_media_file {
+                              localFile {
+                                publicURL
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ... on paragraph__media_text {
+              field_media_text_title
+              field_media_text_desc {
+                processed
+              }
+              field_media_text_links {
+                title
+                uri
+              }
+              relationships {
+                field_media_text_media {
+                  ... on media__image {
+                    name
+                    field_media_image {
+                      alt
+                    }
+                    relationships {
+                      field_media_image {
+                        localFile {
+                          publicURL
+                          childImageSharp {
+                            gatsbyImageData(width: 800, placeholder: BLURRED, layout: CONSTRAINED)
+                          }
+                        }
+                      }
+                    }
+                  }
+                  ... on media__remote_video {
+                    drupal_id
+                    name
+                    field_media_oembed_video
+                    relationships {
+                      field_media_file {
+                        localFile {
+                          publicURL
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -486,7 +486,6 @@ function prepareVariantHeading (variantData) {
           </section>
         </div>
       }
-      {console.log(footerData)}
       {contentExists(footerData) && footerData.length !== 0 &&
         <CustomFooter footerData={footerData[0]} />
       }     

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -486,7 +486,7 @@ function prepareVariantHeading (variantData) {
           </section>
         </div>
       }
-      
+      {console.log(footerData)}
       {contentExists(footerData) && footerData.length !== 0 &&
         <CustomFooter footerData={footerData[0]} />
       }     


### PR DESCRIPTION
# Summary of changes
- Add the content type Custom Footer content to pages based on tags (units).
 - both Basic Page and Custom Footer content needs to be tagged with a Units tag (one).

## Frontend
- modifed gatsby-node.js and basic-page.js to include 
 - modified queries to add unit tag and to filter for custom footer based on the unit tag.
 - added code in basic-page.js to display custom footer content if it exists.
 
## Backend
- no changes

# Test Plan
- in gatsby cloud - https://gusbasicfooter.gatsbyjs.io/
- page that has a footer - https://gusbasicfooter.gatsbyjs.io/alumni/ovc-alumni-association-awards
- page that does not have a footer - https://gusbasicfooter.gatsbyjs.io/studentexperience/off-campus-community-standards-protocol

- To add a custom footer
 - add unit tag to taxonomy (note Ontario Veterinary College is the only one currently) 
 - add content 
  - Custom Footer - add some content in the Body field - select a unit in the tags field.
  - Go to a basic page (or add a new one) then add a unit tag to the tags field. 
  - build site in gatsby cloud and check to see if custom footer is displayed. 


