### PR TITLE
Update UG script and fix video

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -57,9 +57,9 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
             defer
         />,
         <script 
-            key="https://www.uoguelph.ca/js/uog-scripts-dist.js"
-            src="https://www.uoguelph.ca/js/uog-scripts-dist.js"
-            defer
+            key="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js"
+            src="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js" 
+            defer 
         />
     ])
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -25,15 +25,17 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
         />,
         <link 
             key="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400;700&display=swap" 
-            rel="preload" as="style" 
+            rel="stylesheet preload prefetch" as="style" 
             href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400;700&display=swap" 
+            crossOrigin="anonymous"
         />,
         <link 
             key="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400;700&display=swap" 
-            rel="stylesheet" 
+            rel="stylesheet preload prefetch" as="style"
             href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;400;700&display=swap" 
             media="print" 
             onLoad="this.media='all'" 
+            crossOrigin="anonymous"
         />
     ])
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -13,9 +13,9 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
             defer
         />,
         <link
-            key="https://www.uoguelph.ca/css/UofG-bs5-styles-dist.css" 
+            key="https://www.uoguelph.ca/css/UofG-styles-dist.css" 
             rel="stylesheet" 
-            href="https://www.uoguelph.ca/css/UofG-bs5-styles-dist.css" 
+            href="https://www.uoguelph.ca/css/UofG-styles-dist.css" 
         />,
         <link 
             key="https://fonts.gstatic.com" 
@@ -42,7 +42,6 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
             key="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js" 
             src="https://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.4.1.min.js"
             crossOrigin="anonymous"
-            defer
         />,
         <script
             key="https://kit.fontawesome.com/7993323d0c.js"

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -8,24 +8,24 @@ import { contentExists } from 'utils/ug-utils';
 
 function MediaText (props) {
 
-	const mediaTitle = (contentExists(props.widgetData.field_media_text_title) ? props.widgetData.field_media_text_title : ``);
-	const mediaDescription = (contentExists(props.widgetData.field_media_text_desc) ? props.widgetData.field_media_text_desc.processed: ``);
-	const mediaLinks = props.widgetData.field_media_text_links;	
-	const mediaRelationships = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.relationships: ``);
-	
-	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
-	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
-  const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_media_image_size) ? props.widgetData.field_media_image_size : ``);
+    const mediaTitle = (contentExists(props.widgetData.field_media_text_title) ? props.widgetData.field_media_text_title : ``);
+    const mediaDescription = (contentExists(props.widgetData.field_media_text_desc) ? props.widgetData.field_media_text_desc.processed: ``);
+    const mediaLinks = props.widgetData.field_media_text_links;	
+    const mediaRelationships = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.relationships: ``);
+
+    const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
+    const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
+    const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_media_image_size) ? props.widgetData.field_media_image_size : ``);
+
+    const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
+    const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
+    const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);
+    const videoCC = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_video_cc) ? mediaRelationships.field_video_cc.localFile.publicURL : ``);
+    const videoType = (videoURL?.includes("youtube") || videoURL?.includes("youtu.be") ? `youtube` : `vimeo`);
+    const videoID = (videoType === `youtube` ? videoURL?.substr(videoURL?.length - 11) : videoURL?.substr(18));
     
-  const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
-	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
-	const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);
-	const videoCC = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_video_cc) ? mediaRelationships.field_video_cc.localFile.publicURL : ``);
-  const videoType = (videoURL?.includes("youtube") || videoURL?.includes("youtu.be") ? `youtube` : `vimeo`);
-  const videoID = (videoType === `youtube` ? videoURL?.substr(videoURL?.length - 11) : videoURL?.substr(18));
-    
-  let mediaCol;
-  let textCol;
+    let mediaCol;
+    let textCol;
     
     if (contentExists(imageSize)) {
         switch(imageSize) {
@@ -51,16 +51,15 @@ function MediaText (props) {
         textCol = props.colClass;
     }
     
-	return <>	
-
+    return <>
         <section className={mediaCol}>
-			{contentExists(videoURL) ?
-        <Video playerID={playerID} videoType={videoType} videoID={videoID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
-			: ``}
-			{contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
+            {contentExists(videoURL) ?
+            <Video playerID={playerID} videoType={videoType} videoID={videoID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
+            : ``}
+            {contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
         </section>
         <section className={textCol}>
-            {contentExists(props.headingClass) ? <h3 className={props.headingClass}>{mediaTitle}</h3> : <h3>{mediaTitle}</h3>}
+            {contentExists(mediaTitle) ? <h3 {...(contentExists(props.headingClass) ? {className:props.headingClass} : {})}>{mediaTitle}</h3> : ``}
             <div dangerouslySetInnerHTML={{ __html: mediaDescription}} />
             {contentExists(props.widgetData.relationships.field_button_section) === true && <SectionButtons pageData={props.widgetData.relationships.field_button_section} />}
             {contentExists(props.widgetData.relationships.field_button_section) === false && <div>{mediaLinks.map(mediaLink => {
@@ -72,18 +71,17 @@ function MediaText (props) {
                 
             })}</div>}
         </section>
-		
-	</>;
+    </>;
 }
 
 MediaText.propTypes = {
     widgetData: PropTypes.object,
-	colClass: PropTypes.string,
+    colClass: PropTypes.string,
     headingClass: PropTypes.string,
 }
 MediaText.defaultProps = {
     widgetData: null,
-	colClass: `col-md-6`,
+    colClass: `col-md-6`,
     headingClass: ``,
 }
 

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -27,28 +27,32 @@ function MediaText (props) {
     let mediaCol;
     let textCol;
     
-    if (contentExists(imageSize)) {
-        switch(imageSize) {
-            case "small":
-                mediaCol = "col-md-3";
-                textCol = "col-md-9";
-            break;
-            case "medium":
-                mediaCol = "col-md-4";
-                textCol = "col-md-8";
-            break;
-            case "large":
-                mediaCol = "col-md-6";
-                textCol = "col-md-6";
-            break;
-            default:
-                mediaCol = "col-md-6";
-                textCol = "col-md-6";
-            break;
-        }        
+    if (contentExists(mediaDescription)) {
+        if (contentExists(imageURL) && contentExists(imageSize)) {
+            switch(imageSize) {
+                case "small":
+                    mediaCol = "col-md-3";
+                    textCol = "col-md-9";
+                break;
+                case "medium":
+                    mediaCol = "col-md-4";
+                    textCol = "col-md-8";
+                break;
+                case "large":
+                    mediaCol = "col-md-6";
+                    textCol = "col-md-6";
+                break;
+                default:
+                    mediaCol = "col-md-6";
+                    textCol = "col-md-6";
+                break;
+            }        
+        } else {
+            mediaCol = props.colClass;
+            textCol = props.colClass;
+        }
     } else {
-        mediaCol = props.colClass;
-        textCol = props.colClass;
+        mediaCol = "col-xs-12";
     }
     
     return <>
@@ -58,6 +62,7 @@ function MediaText (props) {
             : ``}
             {contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
         </section>
+        {contentExists(mediaDescription) ?
         <section className={textCol}>
             {contentExists(mediaTitle) ? <h3 {...(contentExists(props.headingClass) ? {className:props.headingClass} : {})}>{mediaTitle}</h3> : ``}
             <div dangerouslySetInnerHTML={{ __html: mediaDescription}} />
@@ -70,6 +75,7 @@ function MediaText (props) {
                 </React.Fragment>)                
             })}</div>}
         </section>
+        : null} 
     </>;
 }
 

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -15,15 +15,17 @@ function MediaText (props) {
 	
 	const imageURL = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.localFile : ``);	
 	const imageAlt = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_image) ? mediaRelationships.field_media_image.alt : ``);
-    const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_media_image_size) ? props.widgetData.field_media_image_size : ``);
+  const imageSize = (contentExists(imageURL) && contentExists(props.widgetData.field_media_image_size) ? props.widgetData.field_media_image_size : ``);
     
-    const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
+  const playerID = (contentExists(props.widgetData.relationships.field_media_text_media) ? props.widgetData.relationships.field_media_text_media.drupal_id : ``);
 	const videoURL = (contentExists(mediaRelationships) ? props.widgetData.relationships.field_media_text_media.field_media_oembed_video : ``);
 	const videoTranscript = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_media_file) ? mediaRelationships.field_media_file.localFile.publicURL : ``);
 	const videoCC = (contentExists(mediaRelationships) && contentExists(mediaRelationships.field_video_cc) ? mediaRelationships.field_video_cc.localFile.publicURL : ``);
+  const videoType = (videoURL?.includes("youtube") || videoURL?.includes("youtu.be") ? `youtube` : `vimeo`);
+  const videoID = (videoType === `youtube` ? videoURL?.substr(videoURL?.length - 11) : videoURL?.substr(18));
     
-    let mediaCol;
-    let textCol;
+  let mediaCol;
+  let textCol;
     
     if (contentExists(imageSize)) {
         switch(imageSize) {
@@ -53,7 +55,7 @@ function MediaText (props) {
 
         <section className={mediaCol}>
 			{contentExists(videoURL) ?
-			<Video playerID={playerID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
+        <Video playerID={playerID} videoType={videoType} videoID={videoID} videoURL={videoURL} videoTranscript={videoTranscript} videoCC={videoCC} />
 			: ``}
 			{contentExists(imageURL) ? <GatsbyImage image={imageURL.childImageSharp.gatsbyImageData} alt={imageAlt} /> : ``}
         </section>

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -67,8 +67,7 @@ function MediaText (props) {
                 <React.Fragment>
                     {(mediaLink.uri.includes("http"))? <><a className="btn btn-outline-info" href={mediaLink.url}>{mediaLink.title}</a> </> :
                     <Link to={mediaLink.url} className="btn btn-outline-info" >{mediaLink.title}</Link>}
-                </React.Fragment>)
-                
+                </React.Fragment>)                
             })}</div>}
         </section>
     </>;

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -55,17 +55,14 @@ function SectionWidgets (props) {
                 return <div className={ctaClassName}><CtaPara pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__media_text") {
-                let divColClass;
                 let mediaColClass;
                 const mediaSectionCol = contentExists(widgetData.relationships.field_section_column) ? widgetData.relationships.field_section_column.name : '';
                 if (mediaSectionCol === "left" || mediaSectionCol === "right") {
-                    divColClass = "col-md-6 mt-5";
                     mediaColClass = "col-md-6";
                 } else {
-                    divColClass = "mt-5";
-                    mediaColClass = "col-md-6";
+                    mediaColClass = "col-xs-12";
                 }
-                return <div className={divColClass}><div className="row"><MediaText colClass={mediaColClass} widgetData={widgetData} /></div></div>;			
+                return <div className="col-md-6 mt-5"><div className="row"><MediaText colClass={mediaColClass} widgetData={widgetData} /></div></div>;			
             }
             else if (widgetData.__typename==="paragraph__stats_widget") {
                 const statsClassName=contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -52,9 +52,7 @@ function SectionWidgets (props) {
             }
             else if (widgetData.__typename==="paragraph__call_to_action") {
                 const ctaClassName = contentExists(widgetData.relationships.field_section_column)? "flex-even section-"+widgetData.relationships.field_section_column.name: '';
-                return( <div className={ctaClassName}>
-                        <CtaPara pageData={widgetData} />
-                        </div>);
+                return <div className={ctaClassName}><CtaPara pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__media_text") {
                 let divColClass;
@@ -70,20 +68,12 @@ function SectionWidgets (props) {
                 return <div className={divColClass}><div className="row"><MediaText colClass={mediaColClass} widgetData={widgetData} /></div></div>;			
             }
             else if (widgetData.__typename==="paragraph__stats_widget") {
-                const statsClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-                return (
-                        <div className = {statsClassName} >
-                            <StatsWidget statsWidgetData={widgetData} />
-                        </div>
-                );                
+                const statsClassName=contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
+                return <div className={statsClassName}><StatsWidget statsWidgetData={widgetData} /></div>;                
             }
             else if (widgetData.__typename==="paragraph__lead_paragraph") {
                 const leadClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-                return (
-                        <div className = {leadClassName} >
-                            <LeadPara pageData={widgetData} />
-                        </div>
-                );
+                return <div className={leadClassName}><LeadPara pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
                 const textClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
@@ -91,14 +81,10 @@ function SectionWidgets (props) {
             }
             else if (widgetData.__typename==="paragraph__section_buttons") {
                 const sbtnClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-                return(
-                    <div className={sbtnClassName}>
-                        <SectionButtons pageData={widgetData} />
-                    </div>
-                );
+                return <div className={sbtnClassName}><SectionButtons pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__new_widget") {
-                return(<p>This is Paragraph_new_widget</p>);
+                return <p>This is Paragraph_new_widget</p>;
            }
            return null;
         }))

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -56,13 +56,16 @@ function SectionWidgets (props) {
             }
             else if (widgetData.__typename==="paragraph__media_text") {
                 let mediaColClass;
+                let headingClass;
                 const mediaSectionCol = contentExists(widgetData.relationships.field_section_column) ? widgetData.relationships.field_section_column.name : '';
                 if (mediaSectionCol === "left" || mediaSectionCol === "right") {
                     mediaColClass = "col-md-6";
+                    headingClass = "mt-md-0";
                 } else {
                     mediaColClass = "col-xs-12";
+                    headingClass = "";
                 }
-                return <div className="col-md-6 mt-5"><div className="row"><MediaText colClass={mediaColClass} widgetData={widgetData} /></div></div>;			
+                return <div className="col-md-6 mt-5"><div className="row"><MediaText colClass={mediaColClass} headingClass={headingClass} widgetData={widgetData} /></div></div>;			
             }
             else if (widgetData.__typename==="paragraph__stats_widget") {
                 const statsClassName=contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -55,17 +55,30 @@ function SectionWidgets (props) {
                 return <div className={ctaClassName}><CtaPara pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__media_text") {
+                let divColClass;
                 let mediaColClass;
                 let headingClass;
+                const isImage = contentExists(widgetData.relationships.field_media_text_media.relationships.field_media_image) ? true : false;
                 const mediaSectionCol = contentExists(widgetData.relationships.field_section_column) ? widgetData.relationships.field_section_column.name : '';
-                if (mediaSectionCol === "left" || mediaSectionCol === "right") {
+                
+                if (isImage && (mediaSectionCol === "left" || mediaSectionCol === "right")) {
+                    divColClass = "col-md-6 mt-5";
                     mediaColClass = "col-md-6";
                     headingClass = "mt-md-0";
-                } else {
+                } else if (isImage && mediaSectionCol === "main") {
+                    divColClass = "col-md-6 mt-5";
                     mediaColClass = "col-xs-12";
                     headingClass = "";
-                }
-                return <div className="col-md-6 mt-5"><div className="row"><MediaText colClass={mediaColClass} headingClass={headingClass} widgetData={widgetData} /></div></div>;			
+                } else if (!isImage && (mediaSectionCol === "left" || mediaSectionCol === "right")) {
+                    divColClass = "col-xs-12";
+                    mediaColClass = "col-xs-12";
+                    headingClass = "";
+                } else if (!isImage && mediaSectionCol === "main") {
+                    divColClass = "col-md-6 mt-5";
+                    mediaColClass = "col-xs-12";
+                    headingClass = "";
+                }            
+                return <div className={divColClass}><div className="row"><MediaText colClass={mediaColClass} headingClass={headingClass} widgetData={widgetData} /></div></div>;			
             }
             else if (widgetData.__typename==="paragraph__stats_widget") {
                 const statsClassName=contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -61,22 +61,28 @@ function SectionWidgets (props) {
                 const isImage = contentExists(widgetData.relationships.field_media_text_media.relationships.field_media_image) ? true : false;
                 const mediaSectionCol = contentExists(widgetData.relationships.field_section_column) ? widgetData.relationships.field_section_column.name : '';
                 
-                if (isImage && (mediaSectionCol === "left" || mediaSectionCol === "right")) {
-                    divColClass = "col-md-6 mt-5";
-                    mediaColClass = "col-md-6";
-                    headingClass = "mt-md-0";
-                } else if (isImage && mediaSectionCol === "main") {
-                    divColClass = "col-md-6 mt-5";
-                    mediaColClass = "col-xs-12";
+                if (isImage) {
+                    divColClass = "col-md-6 mt-5";                     
+                    if (mediaSectionCol === "left" || mediaSectionCol === "right") {                                               
+                        mediaColClass = "col-md-6";
+                        headingClass = "mt-md-0";
+                    } else {
+                        mediaColClass = "col-xs-12";
+                        headingClass = "";
+                    }                  
+                } else {
                     headingClass = "";
-                } else if (!isImage && (mediaSectionCol === "left" || mediaSectionCol === "right")) {
-                    divColClass = "col-xs-12";
                     mediaColClass = "col-xs-12";
-                    headingClass = "";
-                } else if (!isImage && mediaSectionCol === "main") {
-                    divColClass = "col-md-6 mt-5";
-                    mediaColClass = "col-xs-12";
-                    headingClass = "";
+                    switch(mediaSectionCol) {
+                        case "left":
+                        divColClass = "section-left";
+                        break;
+                        case "right":
+                        divColClass = "section-right";
+                        break;
+                        default:
+                        divColClass = "col-md-6 mt-5";
+                    }
                 }            
                 return <div className={divColClass}><div className="row"><MediaText colClass={mediaColClass} headingClass={headingClass} widgetData={widgetData} /></div></div>;			
             }

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -21,97 +21,98 @@ import 'styles/widgets.css';
 
 function SectionWidgets (props) {
 
-if (contentExists(props.pageData) && props.pageData.length !== 0) {
-    return (props.pageData.map(widgetData => {
-        if (widgetData.__typename==="paragraph__links_widget") {
-            
-            const gridFirstHeadingLevel = "h2";
-            const listFirstHeadingLevel = "h2";
+    if (contentExists(props.pageData) && props.pageData.length !== 0) {
+        return (props.pageData.map(widgetData => {
+            if (widgetData.__typename==="paragraph__links_widget") {
+                
+                const gridFirstHeadingLevel = "h2";
+                const listFirstHeadingLevel = "h2";
 
-    // if there is at least one links widget (paragarph__links_widget) - step through each one to display links 
-    // if there are link items on the page display them using LinksItems
-    // if the first element has an image - display as a grid otherwise display as a list with no images (not srue if this is the best way to do this, but it works)
-    // logic could be added to have a selction of layout - 
-    // to use - call LinksItems - passing the array of links (pictures optional)
-    // - set level heading to start at h2 for grid and list, option to change. 
-    
-            const linksDisplayType = (contentExists(widgetData.relationships.field_link_items[0].relationships.field_link_image))? 'grid': 'list';
-            const headingLevel = (linksDisplayType === 'grid')? gridFirstHeadingLevel: listFirstHeadingLevel;
-            const numColumns = (linksDisplayType === 'grid')? 4: null;
+        // if there is at least one links widget (paragarph__links_widget) - step through each one to display links 
+        // if there are link items on the page display them using LinksItems
+        // if the first element has an image - display as a grid otherwise display as a list with no images (not srue if this is the best way to do this, but it works)
+        // logic could be added to have a selction of layout - 
+        // to use - call LinksItems - passing the array of links (pictures optional)
+        // - set level heading to start at h2 for grid and list, option to change. 
         
-            return ( <div className="flex-even">
-                        <LinksItems key={widgetData.drupal_id}
-                                    pageData={widgetData.relationships.field_link_items} 
-                                    displayType={linksDisplayType} 
-                                    heading={widgetData.field_link_items_title} 
-                                    headingLevel={headingLevel} 
-                                    description={widgetData.field_link_items_description}
-                                    numColumns={numColumns}/>
-                    </div>
-            )
-        }
-        else if (widgetData.__typename==="paragraph__call_to_action") {
-            const ctaClassName = contentExists(widgetData.relationships.field_section_column)? "flex-even section-"+widgetData.relationships.field_section_column.name: '';
-            return( <div className={ctaClassName}>
-                    <CtaPara pageData={widgetData} />
-                    </div>);
-		} 
-		else if (widgetData.__typename==="paragraph__media_text") {
-            const mediaClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';	
-            const colClassName = "flex-even " + mediaClassName;		
-            const colClass = "col-xlg-12"
-			return (<div className= {colClassName}><MediaText colClass={colClass} widgetData={widgetData} /></div>);
-			
-		}
-		else if (widgetData.__typename==="paragraph__stats_widget") {
-            const statsClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-			return (
-                    <div className = {statsClassName} >
-                        <StatsWidget statsWidgetData={widgetData} />
-                    </div>
-            );
-			
-		}
-        else if (widgetData.__typename==="paragraph__lead_paragraph") {
-            const leadClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-			return (
-                    <div className = {leadClassName} >
-                        <LeadPara pageData={widgetData} />
-                    </div>
-            );
+                const linksDisplayType = (contentExists(widgetData.relationships.field_link_items[0].relationships.field_link_image))? 'grid': 'list';
+                const headingLevel = (linksDisplayType === 'grid')? gridFirstHeadingLevel: listFirstHeadingLevel;
+                const numColumns = (linksDisplayType === 'grid')? 4: null;
             
-		}
-        else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
+                return ( <div className="flex-even">
+                            <LinksItems key={widgetData.drupal_id}
+                                        pageData={widgetData.relationships.field_link_items} 
+                                        displayType={linksDisplayType} 
+                                        heading={widgetData.field_link_items_title} 
+                                        headingLevel={headingLevel} 
+                                        description={widgetData.field_link_items_description}
+                                        numColumns={numColumns}/>
+                        </div>
+                )
+            }
+            else if (widgetData.__typename==="paragraph__call_to_action") {
+                const ctaClassName = contentExists(widgetData.relationships.field_section_column)? "flex-even section-"+widgetData.relationships.field_section_column.name: '';
+                return( <div className={ctaClassName}>
+                        <CtaPara pageData={widgetData} />
+                        </div>);
+            }
+            else if (widgetData.__typename==="paragraph__media_text") {
+                let divColClass;
+                let mediaColClass;
+                const mediaSectionCol = contentExists(widgetData.relationships.field_section_column) ? widgetData.relationships.field_section_column.name : '';
+                if (mediaSectionCol === "left" || mediaSectionCol === "right") {
+                    divColClass = "col-md-6 mt-5";
+                    mediaColClass = "col-md-6";
+                } else {
+                    divColClass = "mt-5";
+                    mediaColClass = "col-md-6";
+                }
+                return <div className={divColClass}><div className="row"><MediaText colClass={mediaColClass} widgetData={widgetData} /></div></div>;			
+            }
+            else if (widgetData.__typename==="paragraph__stats_widget") {
+                const statsClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
+                return (
+                        <div className = {statsClassName} >
+                            <StatsWidget statsWidgetData={widgetData} />
+                        </div>
+                );                
+            }
+            else if (widgetData.__typename==="paragraph__lead_paragraph") {
+                const leadClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
+                return (
+                        <div className = {leadClassName} >
+                            <LeadPara pageData={widgetData} />
+                        </div>
+                );
+            }
+            else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
                 const textClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-        return <div className={textClassName } dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 
+                return <div className={textClassName } dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 
+            }
+            else if (widgetData.__typename==="paragraph__section_buttons") {
+                const sbtnClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
+                return(
+                    <div className={sbtnClassName}>
+                        <SectionButtons pageData={widgetData} />
+                    </div>
+                );
+            }
+            else if (widgetData.__typename==="paragraph__new_widget") {
+                return(<p>This is Paragraph_new_widget</p>);
+           }
+           return null;
+        }))
     }
-        else if (widgetData.__typename==="paragraph__section_buttons") {
-            const sbtnClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-            return(
-                <div className={sbtnClassName}>
-                    <SectionButtons pageData={widgetData} />
-                </div>
-            );
-        }
-       else if (widgetData.__typename==="paragraph__new_widget") {
-        return(<p>This is Paragraph_new_widget</p>);
-       }
-       return null;
-    }
-        ))
-}
     return null;
-
-   
 }
+
 SectionWidgets.propTypes = {
     pageData: PropTypes.array,
    
 }
 SectionWidgets.defaultProps = {
     pageData: ``,
-
-  }
+}
 
 export default SectionWidgets
 

--- a/src/components/shared/video.js
+++ b/src/components/shared/video.js
@@ -29,7 +29,7 @@ function Video (props) {
                                 <span className="sr-only">Loading...</span>
                             </div>
                         </div>
-                        <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls">
+                        <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls" crossOrigin="anonymous">
                             <source type={`video/` + videoType} src={videoSrc} />
                             {contentExists(videoCC) && <track className="caption-input" label="English" kind="subtitles" srcLang="en" src={videoCC} default={true} /> }
                             {contentExists(videoTranscript) && <link className="transcript-input" rel="transcript" label="English" kind="descriptions" srcLang="en" src={videoTranscript} default={true} /> }

--- a/src/components/shared/video.js
+++ b/src/components/shared/video.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Helmet } from 'react-helmet';
 import { graphql } from 'gatsby';
 import { contentExists } from 'utils/ug-utils';
 
@@ -7,8 +8,8 @@ function Video (props) {
     let playerID = props.playerID;
     let videoCC = props.videoCC;
     let videoTranscript = props.videoTranscript;
-    let videoType = (props.videoURL.includes("youtube") || props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
-    let videoID = (videoType === `youtube` ? props.videoURL.substr(props.videoURL.length - 11) : props.videoURL.substr(18));
+    let videoType = props.videoType;
+    let videoID = props.videoID;
 
     let youtubeURL = "https://www.youtube.com/embed/";
     let vimeoURL = "https://player.vimeo.com/video/";	
@@ -16,8 +17,11 @@ function Video (props) {
     
     return (
         <React.Fragment>
+        <Helmet>
+            <script src="https://www.uoguelph.ca/js/uog-media-player.js" defer></script>
+        </Helmet>
         <div>
-            <div id="video-embed">
+            <div id={`video-embed-${playerID}`}>
                 <section name={videoType} className="ui-kit-section">
                     <div className="embed-responsive embed-responsive-16by9">
                         <div className="d-flex justify-content-center">
@@ -27,10 +31,8 @@ function Video (props) {
                         </div>
                         <video className="ugplayer embed-responsive-item" width="100%" id={playerID} preload="none" controls="controls">
                             <source type={`video/` + videoType} src={videoSrc} />
-                            {contentExists(videoTranscript) ? 
-                            <><track className="caption-input" label="English" kind="subtitles" srclang="en" src={videoCC} default="true" />
-                            <link className="transcript-input" rel="transcript" label="English" kind="descriptions" srclang="en" src={videoTranscript} default="true" /></>
-                            : ``}
+                            {contentExists(videoCC) && <track className="caption-input" label="English" kind="subtitles" srcLang="en" src={videoCC} default={true} /> }
+                            {contentExists(videoTranscript) && <link className="transcript-input" rel="transcript" label="English" kind="descriptions" srcLang="en" src={videoTranscript} default={true} /> }
                         </video>
                     </div>
                 </section>


### PR DESCRIPTION
# Summary of changes
Update external UoG scripts link and move UoG media player script call. Fixes bug where videos won't load unless a full page refresh occurs. The section widget component has also been refactored to allow for more versatile multi-column layouts.

## Frontend
- Update `gatsby-ssr.js` to:
    - call new, refactored UoG scripts file
    - include latest UG CSS file
    - fix calls to Google font files so Roboto font loads correctly
- Update `video.js` to call `uog-media-player.js` directly
- Refactor `sectionWidgets.js` to use Bootstrap 5 classes and handle different media and text layouts
- General code cleanup

## Backend
None.

# Test Plan

- Go to https://www.gatsbyjs.com/dashboard/2e86c058-a370-4898-ae51-9698cd178e8d/sites/fc8e90a4-54ce-4012-a5fc-3302f05a3d6d/deploys
- Go to "Visit build" for the latest version of this PR build
- Visit the following pages and ensure videos load, play, display captions, and have a downloadable transcript. You should not have to reload the page or open it in a separate tab (i.e. if, from the main index page, you go to "Welcome Home", use the Back button, and then navigate to another page with video, that video should load properly without requiring a hard refresh):
    - /welcome-home
    - /land-acknowledgement
    - /studentexperience/become-a-peer-helper
    - /vimeo-test
- Visit /grce/contact and verify it has a similar layout to https://www.uoguelph.ca/grce/contact
- Visit /choose-u-of-g and verify the images near the bottom still appear side-by-side with text underneath as they do on https://www.uoguelph.ca/choose-u-of-g

