### PR TITLE
Refactor Accordion widget for Bootstrap 5

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -401,6 +401,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__accordion_block implements Node {
       drupal_id: String
       field_accordion_block_text: FieldAccordionBlockText
+      field_accordion_stay_open: Boolean
       field_accordion_title: String
     }
     type paragraph__accordion_section implements Node {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -400,12 +400,12 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }  
     type paragraph__accordion_block implements Node {
       drupal_id: String
-      field_accordion_block_text: FieldAccordionBlockText
-      field_accordion_stay_open: Boolean
+      field_accordion_block_text: FieldAccordionBlockText      
       field_accordion_title: String
     }
     type paragraph__accordion_section implements Node {
       drupal_id: String
+      field_accordion_stay_open: Boolean
       relationships: paragraph__accordion_sectionRelationships
     }
     type paragraph__accordion_sectionRelationships implements Node {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -144,12 +144,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       format: String
       summary: String
     }
-    type FieldAccordionBlockTitle {
-      processed: String
-      value: String
-      format: String
-      summary: String
-    }
     type FieldFormattedTitle {
       processed: String
       value: String
@@ -407,7 +401,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__accordion_block implements Node {
       drupal_id: String
       field_accordion_block_text: FieldAccordionBlockText
-      field_accordion_block_title: FieldAccordionBlockTitle
+      field_accordion_title: String
     }
     type paragraph__accordion_section implements Node {
       drupal_id: String

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -14,7 +14,7 @@ const Accordion = (props) => {
             {accordionData.map(item =>
                 <div className="accordion-item" key={"item" + item.drupal_id}>
                     <h2 className="accordion-header" id={"heading" + item.drupal_id}>
-                        <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls={"part" + item.drupal_id}>
+                        <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="false" aria-controls={"part" + item.drupal_id}>
                             {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -12,13 +12,13 @@ const Accordion = (props) => {
         return <>
             <div className="accordion" id={"accordion" + props.pageData.drupal_id}>
             {accordionData.map(item =>
-                <div className="accordion-item">
+                <div className="accordion-item" key={"item" + item.drupal_id}>
                     <h2 className="accordion-header" id={"heading" + item.drupal_id}>
                         <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls={"part" + item.drupal_id}>
                             {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>
-                    <div {...(stayOpen ? {} : {["data-bs-parent"]:dataParent})} id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={"heading" + item.drupal_id}>            
+                    <div {...(stayOpen ? {} : {"data-bs-parent":dataParent})} id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={"heading" + item.drupal_id}>            
                         <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>
                 </div>

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -1,9 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 import { contentExists } from 'utils/ug-utils';
 
-const accordionWidget = (props) => {
+const Accordion = (props) => {
     let accordionData = props.pageData.relationships.field_accordion_block_elements;
     let stayOpen = props.pageData.field_accordion_stay_open;
     let dataParent = ("#accordion" + props.pageData.drupal_id);
@@ -29,15 +29,15 @@ const accordionWidget = (props) => {
     return null;
 }
 
-accordionWidget.propTypes = {
+Accordion.propTypes = {
     pageData: PropTypes.object,
 }
   
-accordionWidget.defaultProps = {
+Accordion.defaultProps = {
     pageData: ``,
 }
 
-export default accordionWidget
+export default Accordion
 
 export const query = graphql`
   fragment AccordionSectionParagraphFragment on paragraph__accordion_section {

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -6,17 +6,19 @@ import { contentExists } from 'utils/ug-utils';
 const accordionWidget = (props) => {
     let accordionData = props.pageData.relationships.field_accordion_block_elements;
     let stayOpen = props.pageData.field_accordion_stay_open;
+    let dataParent = ("#accordion" + props.pageData.drupal_id);
+
     if (contentExists(accordionData)) {
         return <>
-            <div className="accordion" id={"accordion" + props.pageData.drupal_id}>            
+            <div className="accordion" id={"accordion" + props.pageData.drupal_id}>
             {accordionData.map(item =>
                 <div className="accordion-item">
-                    <h2 className="accordion-header">
+                    <h2 className="accordion-header" id={"heading" + item.drupal_id}>
                         <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls={"part" + item.drupal_id}>
                             {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>
-                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} {stayOpen ? data-bs-parent={"#accordion" + props.pageData.drupal_id} : ``}>
+                    <div {...(stayOpen ? {} : {["data-bs-parent"]:dataParent})} id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={"heading" + item.drupal_id}>            
                         <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>
                 </div>

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -10,10 +10,10 @@ const accordionWidget = (props) => {
             <div className="accordion" id={"accordion" + props.pageData.drupal_id}>            
             {accordionData.map(item =>
                 <div className="accordion-item">
-                    <h3 className="accordion-header">
+                    <h2 className="accordion-header">
                         <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls="collapseOne" dangerouslySetInnerHTML={{__html: item.field_accordion_block_title.processed}}>
                         </button>
-                    </h3>
+                    </h2>
                     <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} data-bs-parent={"#accordion" + props.pageData.drupal_id}>
                         <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -1,28 +1,28 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { graphql } from 'gatsby';
+import { contentExists } from 'utils/ug-utils';
 
-
-function accordionWidget (props) {
-  
-  return(
-    props.pageData.relationships.field_accordion_block_elements.map((accordionData,j) => {
-        return( <>
-            <div className="panel-group panel-group-lists collapse in show" id={"accordionWidget"+props.pageData.drupal_id}>
-                <div className="panel">
-                    <div className="panel-heading">
-                        <h4 className="panel-title">
-                            <a data-toggle="collapse" data-parent={"#accordionWidget"+props.pageData.drupal_id} href={"#collapse"+j+props.pageData.drupal_id} className="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
-                        </h4>
-                    </div>
-                    <div id={"collapse"+j+props.pageData.drupal_id} className="panel-collapse collapse in">
-                        <div className="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
+const accordionWidget = (props) => {
+    let accordionData = props.pageData.relationships.field_accordion_block_elements;    
+    if (contentExists(accordionData)) {
+        return <>
+            <div className="accordion" id={"accordion" + props.pageData.drupal_id}>            
+            {accordionData.map(item =>
+                <div className="accordion-item">
+                    <h3 className="accordion-header">
+                        <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls="collapseOne" dangerouslySetInnerHTML={{__html: item.field_accordion_block_title.processed}}>
+                        </button>
+                    </h3>
+                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} data-bs-parent={"#accordion" + props.pageData.drupal_id}>
+                        <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>
                 </div>
+            )}
             </div>
-        </>);
-    } )
-);
+        </>
+    }
+    return null;
 }
 
 accordionWidget.propTypes = {
@@ -36,29 +36,29 @@ accordionWidget.defaultProps = {
 export default accordionWidget
 
 export const query = graphql`
-fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
-  drupal_id
-  relationships {
-    field_accordion_block_elements {
-      drupal_id
-      field_accordion_block_title {
-        processed
-      }
-      field_accordion_block_text {
-        processed
+  fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
+    drupal_id
+    relationships {
+      field_accordion_block_elements {
+        drupal_id
+        field_accordion_block_title {
+          processed
+        }
+        field_accordion_block_text {
+          processed
+        }
       }
     }
   }
-}
-fragment GeneralTextParagraphFragment on paragraph__general_text {
-  drupal_id
-  field_general_text {
-    processed
-  }
-  relationships {
-    field_section_column {
-      name
+  fragment GeneralTextParagraphFragment on paragraph__general_text {
+    drupal_id
+    field_general_text {
+      processed
+    }
+    relationships {
+      field_section_column {
+        name
+      }
     }
   }
-} 
 `

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -39,14 +39,14 @@ export default accordionWidget
 export const query = graphql`
   fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
     drupal_id
+    field_accordion_stay_open
     relationships {
       field_accordion_block_elements {
         drupal_id
         field_accordion_title
         field_accordion_block_text {
           processed
-        }
-        field_accordion_stay_open
+        }        
       }
     }
   }

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -53,15 +53,4 @@ export const query = graphql`
       }
     }
   }
-  fragment GeneralTextParagraphFragment on paragraph__general_text {
-    drupal_id
-    field_general_text {
-      processed
-    }
-    relationships {
-      field_section_column {
-        name
-      }
-    }
-  }
 `

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -4,7 +4,8 @@ import { graphql } from 'gatsby';
 import { contentExists } from 'utils/ug-utils';
 
 const accordionWidget = (props) => {
-    let accordionData = props.pageData.relationships.field_accordion_block_elements;    
+    let accordionData = props.pageData.relationships.field_accordion_block_elements;
+    let stayOpen = props.pageData.field_accordion_stay_open;
     if (contentExists(accordionData)) {
         return <>
             <div className="accordion" id={"accordion" + props.pageData.drupal_id}>            
@@ -15,7 +16,7 @@ const accordionWidget = (props) => {
                             {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>
-                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} {item.field_accordion_stay_open ? data-bs-parent={"#accordion" + props.pageData.drupal_id} : ``}>
+                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} {stayOpen ? data-bs-parent={"#accordion" + props.pageData.drupal_id} : ``}>
                         <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>
                 </div>

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -11,7 +11,8 @@ const accordionWidget = (props) => {
             {accordionData.map(item =>
                 <div className="accordion-item">
                     <h2 className="accordion-header">
-                        <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls="collapseOne" dangerouslySetInnerHTML={{__html: item.field_accordion_block_title.processed}}>
+                        <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls={"part" + item.drupal_id}>
+                            {contentExists(field_accordion_title) ? field_accordion_title : "Read More"}
                         </button>
                     </h2>
                     <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} data-bs-parent={"#accordion" + props.pageData.drupal_id}>
@@ -41,9 +42,7 @@ export const query = graphql`
     relationships {
       field_accordion_block_elements {
         drupal_id
-        field_accordion_block_title {
-          processed
-        }
+        field_accordion_title
         field_accordion_block_text {
           processed
         }

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -15,7 +15,7 @@ const accordionWidget = (props) => {
                             {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>
-                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} data-bs-parent={"#accordion" + props.pageData.drupal_id}>
+                    <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} {item.field_accordion_stay_open ? data-bs-parent={"#accordion" + props.pageData.drupal_id} : ``}>
                         <div className="accordion-body" dangerouslySetInnerHTML={{__html: item.field_accordion_block_text.processed}} />
                     </div>
                 </div>
@@ -46,6 +46,7 @@ export const query = graphql`
         field_accordion_block_text {
           processed
         }
+        field_accordion_stay_open
       }
     }
   }

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -12,7 +12,7 @@ const accordionWidget = (props) => {
                 <div className="accordion-item">
                     <h2 className="accordion-header">
                         <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target={"#part" + item.drupal_id} aria-expanded="true" aria-controls={"part" + item.drupal_id}>
-                            {contentExists(field_accordion_title) ? field_accordion_title : "Read More"}
+                            {contentExists(item.field_accordion_title) ? item.field_accordion_title : "Read More"}
                         </button>
                     </h2>
                     <div id={"part" + item.drupal_id} className="accordion-collapse collapse" aria-labelledby={item.drupal_id} data-bs-parent={"#accordion" + props.pageData.drupal_id}>

--- a/src/components/shared/accordionWidget.js
+++ b/src/components/shared/accordionWidget.js
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { graphql } from 'gatsby';
+
+
+function accordionWidget (props) {
+  
+  return(
+    props.pageData.relationships.field_accordion_block_elements.map((accordionData,j) => {
+        return( <>
+            <div className="panel-group panel-group-lists collapse in show" id={"accordionWidget"+props.pageData.drupal_id}>
+                <div className="panel">
+                    <div className="panel-heading">
+                        <h4 className="panel-title">
+                            <a data-toggle="collapse" data-parent={"#accordionWidget"+props.pageData.drupal_id} href={"#collapse"+j+props.pageData.drupal_id} className="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
+                        </h4>
+                    </div>
+                    <div id={"collapse"+j+props.pageData.drupal_id} className="panel-collapse collapse in">
+                        <div className="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
+                    </div>
+                </div>
+            </div>
+        </>);
+    } )
+);
+}
+
+accordionWidget.propTypes = {
+    pageData: PropTypes.object,
+}
+  
+accordionWidget.defaultProps = {
+    pageData: ``,
+}
+
+export default accordionWidget
+
+export const query = graphql`
+fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
+  drupal_id
+  relationships {
+    field_accordion_block_elements {
+      drupal_id
+      field_accordion_block_title {
+        processed
+      }
+      field_accordion_block_text {
+        processed
+      }
+    }
+  }
+}
+fragment GeneralTextParagraphFragment on paragraph__general_text {
+  drupal_id
+  field_general_text {
+    processed
+  }
+  relationships {
+    field_section_column {
+      name
+    }
+  }
+} 
+`

--- a/src/components/shared/generalText.js
+++ b/src/components/shared/generalText.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql } from 'gatsby';
+
+const GeneralText = ({textClass, processed}) => (
+    <div className={textClass} dangerouslySetInnerHTML={{__html: processed}}></div>
+)
+
+GeneralText.propTypes = {
+    textClass: PropTypes.string,
+}
+
+GeneralText.defaultProps = {
+    textClass: ``,
+}
+
+export default GeneralText
+
+export const query = graphql`
+  fragment GeneralTextParagraphFragment on paragraph__general_text {
+    drupal_id
+    field_general_text {
+      processed
+    }
+    relationships {
+      field_section_column {
+        name
+      }
+    }
+  }
+`

--- a/src/components/shared/generalText.js
+++ b/src/components/shared/generalText.js
@@ -2,15 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 
-const GeneralText = ({textClass, processed}) => (
-    <div className={textClass} dangerouslySetInnerHTML={{__html: processed}}></div>
-)
+const GeneralText = (props) => {    
+    let processed = props.processed;
+    let textClass = props.textClass;    
+    return <div {...(textClass !== `` ? {className:textClass} : {})} dangerouslySetInnerHTML={{__html: processed}}></div>    
+}
 
 GeneralText.propTypes = {
+    processed: PropTypes.string,
     textClass: PropTypes.string,
 }
 
 GeneralText.defaultProps = {
+    processed: ``,
     textClass: ``,
 }
 

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { graphql } from 'gatsby';
-import LinksItems from 'components/shared/linksItems';
 import CtaPara from 'components/shared/ctaPara'
-import MediaText from 'components/shared/mediaText';
-import StatsWidget from 'components/shared/statsWidget';
+import GeneralText from 'components/shared/generalText';
 import LeadPara from 'components/shared/leadPara';
+import LinksItems from 'components/shared/linksItems';
+import MediaText from 'components/shared/mediaText';
 import SectionButtons from 'components/shared/sectionButtons';
+import StatsWidget from 'components/shared/statsWidget';
 import { contentExists } from 'utils/ug-utils'
 import 'styles/widgets.css';
 // 
@@ -95,8 +96,8 @@ function SectionWidgets (props) {
                 return <div className={leadClassName}><LeadPara pageData={widgetData} /></div>;
             }
             else if (widgetData.__typename==="paragraph__general_text" && contentExists(widgetData.field_general_text.processed)) {
-                const textClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
-                return <div className={textClassName } dangerouslySetInnerHTML={{__html: widgetData.field_general_text.processed }}/>; 
+                const textClass = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';
+                return <GeneralText textClass={textClass} processed={widgetData.field_general_text.processed} />; 
             }
             else if (widgetData.__typename==="paragraph__section_buttons") {
                 const sbtnClassName = contentExists(widgetData.relationships.field_section_column)? "section-"+widgetData.relationships.field_section_column.name: '';

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby';
 import AccordionWidget from 'components/shared/accordionWidget';
 import CtaPara from 'components/shared/ctaPara';
 import Events from 'components/shared/events';
+import GeneralText from 'components/shared/generalText';
 import LeadPara from 'components/shared/leadPara';
 import LinksItems from 'components/shared/linksItems';
 import MediaText from 'components/shared/mediaText';
@@ -10,10 +11,6 @@ import PageTabs from 'components/shared/pageTabs';
 import SectionWidgets from 'components/shared/sectionWidgets';
 import StatsWidget from 'components/shared/statsWidget';
 import { contentExists } from 'utils/ug-utils';
-
-const GeneralText = ({processed}) => (
-    <div dangerouslySetInnerHTML={{__html: processed}}></div>
-  )
 
 const Widget = ({widget}) => {
     switch (widget?.__typename) {

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import AccordionWidget from 'components/shared/accordionWidget';
+import Accordion from 'components/shared/accordion';
 import CtaPara from 'components/shared/ctaPara';
 import Events from 'components/shared/events';
 import GeneralText from 'components/shared/generalText';
@@ -15,7 +15,7 @@ import { contentExists } from 'utils/ug-utils';
 const Widget = ({widget}) => {
     switch (widget?.__typename) {
         case "paragraph__accordion_section":
-            return <AccordionWidget pageData={widget} />;
+            return <Accordion pageData={widget} />;
         case "paragraph__call_to_action":
             return <CtaPara pageData={widget} />;
         case "paragraph__events_widget":

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import AccordionWidget from 'components/shared/accordionWidget';
 import CtaPara from 'components/shared/ctaPara';
 import Events from 'components/shared/events';
 import LeadPara from 'components/shared/leadPara';
@@ -17,24 +18,7 @@ const GeneralText = ({processed}) => (
 const Widget = ({widget}) => {
     switch (widget?.__typename) {
         case "paragraph__accordion_section":
-            return(
-                widget.relationships.field_accordion_block_elements.map((accordionData,j) => {
-                    return( <>
-                        <div className="panel-group panel-group-lists collapse in show" id={"accordionWidget"+widget.drupal_id}>
-                            <div className="panel">
-                                <div className="panel-heading">
-                                    <h4 className="panel-title">
-                                        <a data-toggle="collapse" data-parent={"#accordionWidget"+widget.drupal_id} href={"#collapse"+j+widget.drupal_id} className="collapsed" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_title.processed}}></a>
-                                    </h4>
-                                </div>
-                                <div id={"collapse"+j+widget.drupal_id} className="panel-collapse collapse in">
-                                    <div className="panel-body" dangerouslySetInnerHTML={{__html: accordionData.field_accordion_block_text.processed}}/>
-                                </div>
-                            </div>
-                        </div>
-                    </>);
-                } )
-            );
+            return <AccordionWidget pageData={widget} />;
         case "paragraph__call_to_action":
             return <CtaPara pageData={widget} />;
         case "paragraph__events_widget":
@@ -78,31 +62,7 @@ const Widget = ({widget}) => {
 export default Widget
 
 export const query = graphql`
-  fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
-    drupal_id
-    relationships {
-      field_accordion_block_elements {
-        drupal_id
-        field_accordion_block_title {
-          processed
-        }
-        field_accordion_block_text {
-          processed
-        }
-      }
-    }
-  }
-  fragment GeneralTextParagraphFragment on paragraph__general_text {
-    drupal_id
-    field_general_text {
-      processed
-    }
-    relationships {
-      field_section_column {
-        name
-      }
-    }
-  }  
+ 
   fragment FieldWidgetsFragment on Node {
     __typename
     ... on paragraph__accordion_section {


### PR DESCRIPTION
# Summary of changes
The Accordion widget has been refactored for compatibility with Bootstrap 5. Code for the Accordion and General Text widgets has been moved to separate component files. The title field for Accordion items in the backend has been changed from formatted text to plain.

## Frontend
- New widget files: `accordion.js` and `generalText.js`
- `sectionWidget.js` and `widget.js` modified to use the relevant component files
- Accordion widget code refactored for Bootstrap 5 compatibility as per https://getbootstrap.com/docs/5.0/components/accordion/
- Schema in `gatsby-node.js` updated to use new Accordion title field

## Backend
- New title field created for accordion items (using plain text instead for formatted, thus reducing complexity and the possibility of conflicts with Bootstrap 5 classes)
- New `Stay Open` boolean field created to allow content editors to choose how accordions should function. By default, they will stay open as per https://getbootstrap.com/docs/5.0/components/accordion/#always-open
- Accordion labels and instructions updated for brevity and clarity

# Test Plan

## Backend
- Go to https://tqtest-chug.pantheonsite.io/admin/structure/paragraphs_type to see changes to the Accordion paragraph type
- Go to https://tqtest-chug.pantheonsite.io/sections-and-widgets to see the Accordion widget in use

## Frontend
- Go to https://tqtest.gatsbyjs.io/sections-and-widgets
- Verify each Accordion section behaves as its intro text describes

# Known Issues
Because data already exists for the old Accordion title field, it cannot be removed outright. The backend changes will need to be merged first and then each page using an Accordion widget must be updated (i.e. copy the text from the old title field to the new one). Once this is done, the old title field can be deleted and temporary workaround on line 18 of `accordion.js` can be removed (the workaround was put in place to avoid null errors during development). Then the frontend changes can go live as well.

**Pages on live site to be updated:**
1. https://api.liveugconthub.uoguelph.dev/gceb3
1. https://api.liveugconthub.uoguelph.dev/oac/gceb3
1. https://api.liveugconthub.uoguelph.dev/webadvisor (unpublished)