### PR TITLE
Refactor Breadcrumb for alternate Home options

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -167,11 +167,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       alt: String
     }
     
-    type domain__domain implements Node {
-      drupal_id: String
-      hostname: String
-      name: String
-    }
     type media__image implements Node {
       drupal_id: String
       name: String
@@ -329,17 +324,20 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type node__page implements Node {
       drupal_id: String
       drupal_internal__nid: Int
+      field_domain_access: [node__pageField_domain_access]
       field_hero_image: ImageField
       field_metatags: node__pageField_metatags
       relationships: node__pageRelationships
       fields: FieldsPathAlias
       path: AliasPath
     }
+    type node__pageField_domain_access implements Node {
+      drupal_internal__target_id: String
+    }
     type node__pageField_metatags implements Node {
       og_description: String
     }
     type node__pageRelationships implements Node {
-      field_domain_access: [domain__domain] @link(from: "field_domain_access___NODE")
       field_hero_image: media__image @link(from: "field_hero_image___NODE")
       field_widgets: [widgetParagraphUnion] @link(from:"field_widgets___NODE")
       field_tags: [relatedTaxonomyUnion] @link(from: "field_tags___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -172,7 +172,12 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type ImageField implements Node {
       alt: String
     }
-
+    
+    type domain__domain implements Node {
+      drupal_id: String
+      hostname: String
+      name: String
+    }
     type media__image implements Node {
       drupal_id: String
       name: String
@@ -340,6 +345,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       og_description: String
     }
     type node__pageRelationships implements Node {
+      field_domain_access: [domain__domain] @link(from: "field_domain_access___NODE")
       field_hero_image: media__image @link(from: "field_hero_image___NODE")
       field_widgets: [widgetParagraphUnion] @link(from:"field_widgets___NODE")
       field_tags: [relatedTaxonomyUnion] @link(from: "field_tags___NODE")

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -70,6 +70,10 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                 });                
                 midCrumbs = findCrumbs(pageMenu, endCrumbParent);
                 
+                /***
+                * If there's only one domain and it's the default, set Breadcrumb home to UG homepage
+                * Otherwise, assume use of sitename.uoguelph.ca and use the top menu item as Breadcrumb home
+                ***/
                 if (domains) {
                     if (domains.length === 1 && domains[0].drupal_internal__target_id.includes("liveugconthub")) {
                         homeCrumbURL = "https://www.uoguelph.ca";
@@ -80,7 +84,6 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                         homeCrumbURL = rootItems[0].node.link.url;
                     }                    
                 }
-                console.log(domains);
             }            
         }
         

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -30,7 +30,7 @@ function stripParentID(drupalParentID) {
     }
 }
 
-const makeBreadcrumbTrail = (menuData, domain, menuName, nodeID, nodeTitle) => {
+const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => {
 
     let pageMenu = [];
     let midCrumbs = [];
@@ -56,20 +56,12 @@ const makeBreadcrumbTrail = (menuData, domain, menuName, nodeID, nodeTitle) => {
                 }
             });
             
-            if (pageMenu) {                
+            if (pageMenu) {            
                 pageMenu.forEach(item => {
                     if (!item.node.drupal_parent_menu_item) {
                         rootItems.push(item);
                     }
                 });
-                if (domain !== "api.liveugconthub.uoguelph.dev") {
-                    homeCrumbURL = rootItems[0].node.link.url;
-                } else {
-                    homeCrumbURL = "https://www.uoguelph.ca";
-                    topCrumb = rootItems[0].node.title;
-                    topCrumbID = rootItems[0].node.link.uri;
-                    topCrumbURL = rootItems[0].node.link.url;
-                }
                 pageMenu.forEach(item => {
                     if (item.node.link.uri === currentPage) {
                         endCrumb = item.node.title;
@@ -77,6 +69,18 @@ const makeBreadcrumbTrail = (menuData, domain, menuName, nodeID, nodeTitle) => {
                     }
                 });                
                 midCrumbs = findCrumbs(pageMenu, endCrumbParent);
+                
+                if (domains) {
+                    if (domains.length === 1 && domains[0].drupal_internal__target_id.includes("liveugconthub")) {
+                        homeCrumbURL = "https://www.uoguelph.ca";
+                        topCrumb = rootItems[0].node.title;
+                        topCrumbID = rootItems[0].node.link.uri;
+                        topCrumbURL = rootItems[0].node.link.url; 
+                    } else {
+                        homeCrumbURL = rootItems[0].node.link.url;
+                    }                    
+                }
+                console.log(domains);
             }            
         }
         
@@ -134,19 +138,19 @@ const Breadcrumbs = (props) => (
         }
       `
       }
-      render={data => makeBreadcrumbTrail(data, props.domain, props.menuName, props.nodeID, props.nodeTitle)}
+      render={data => makeBreadcrumbTrail(data, props.domains, props.menuName, props.nodeID, props.nodeTitle)}
    />
 )
 
 Breadcrumbs.propTypes = {
-    domain: PropTypes.string,
+    domains: PropTypes.array,
     menuName: PropTypes.string,
     nodeID: PropTypes.number,
     nodeTitle: PropTypes.string,
 }
 
 Breadcrumbs.defaultProps = {
-    domain: `api.liveugconthub.uoguelph.dev`,
+    domains: [],
     menuName: `main`,
     nodeID: null,
     nodeTitle: ``,

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -9,7 +9,7 @@ import Widget from 'components/shared/widget';
 import CustomFooter from 'components/shared/customFooter';
 import { contentExists } from 'utils/ug-utils';
 
-const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData, widgets, footer, menuName}) => (
+const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData, widgets, footer, menuName, domain}) => (
     <Layout menuName={menuName}>
         <Helmet bodyAttributes={{ class: 'basic-page' }} />
         <Seo title={pageTitle} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
@@ -22,7 +22,7 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
             </div>
         </div>
         
-        <Breadcrumbs menuName={menuName} nodeID={nodeID} nodeTitle={pageTitle} />
+        <Breadcrumbs menuName={menuName} nodeID={nodeID} nodeTitle={pageTitle} domain={domain} />
         
         { /**** Body content ****/ }
         <div className="container page-container">
@@ -51,8 +51,8 @@ export const query = graphql`
         alias
       }
       relationships {
-        field_widgets {
-          ...FieldWidgetsFragment
+        field_domain_access {
+          hostname
         }
         field_tags {
           __typename
@@ -61,6 +61,9 @@ export const query = graphql`
             id
             name
           }
+        }
+        field_widgets {
+          ...FieldWidgetsFragment
         }
       }
     }
@@ -104,6 +107,7 @@ const PageTemplate = ({data}) => (
         widgets={data.nodePage.relationships.field_widgets}
         footer={data.footer.edges}
         menuName={data.menu?.menu_name || `main`}
+        domain={data.nodePage.relationships.field_domain_access[0].hostname}
     ></Page>
 )
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -9,7 +9,7 @@ import Widget from 'components/shared/widget';
 import CustomFooter from 'components/shared/customFooter';
 import { contentExists } from 'utils/ug-utils';
 
-const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData, widgets, footer, menuName, domain}) => (
+const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData, widgets, footer, menuName, domains}) => (
     <Layout menuName={menuName}>
         <Helmet bodyAttributes={{ class: 'basic-page' }} />
         <Seo title={pageTitle} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
@@ -22,7 +22,7 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
             </div>
         </div>
         
-        <Breadcrumbs menuName={menuName} nodeID={nodeID} nodeTitle={pageTitle} domain={domain} />
+        <Breadcrumbs menuName={menuName} nodeID={nodeID} nodeTitle={pageTitle} domains={domains} />
         
         { /**** Body content ****/ }
         <div className="container page-container">
@@ -44,6 +44,9 @@ export const query = graphql`
       drupal_id
       drupal_internal__nid
       title
+      field_domain_access {
+        drupal_internal__target_id
+      }
       field_metatags {
         og_description
       }
@@ -51,9 +54,6 @@ export const query = graphql`
         alias
       }
       relationships {
-        field_domain_access {
-          hostname
-        }
         field_tags {
           __typename
           ... on TaxonomyInterface {
@@ -107,7 +107,7 @@ const PageTemplate = ({data}) => (
         widgets={data.nodePage.relationships.field_widgets}
         footer={data.footer.edges}
         menuName={data.menu?.menu_name || `main`}
-        domain={data.nodePage.relationships.field_domain_access[0]?.hostname || `api.liveugconthub.uoguelph.dev`}
+        domains={data.nodePage.field_domain_access}
     ></Page>
 )
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -107,7 +107,7 @@ const PageTemplate = ({data}) => (
         widgets={data.nodePage.relationships.field_widgets}
         footer={data.footer.edges}
         menuName={data.menu?.menu_name || `main`}
-        domain={data.nodePage.relationships.field_domain_access[0].hostname}
+        domain={data.nodePage.relationships.field_domain_access[0].hostname || `api.liveugconthub.uoguelph.dev`}
     ></Page>
 )
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -107,7 +107,7 @@ const PageTemplate = ({data}) => (
         widgets={data.nodePage.relationships.field_widgets}
         footer={data.footer.edges}
         menuName={data.menu?.menu_name || `main`}
-        domain={data.nodePage.relationships.field_domain_access[0].hostname || `api.liveugconthub.uoguelph.dev`}
+        domain={data.nodePage.relationships.field_domain_access[0]?.hostname || `api.liveugconthub.uoguelph.dev`}
     ></Page>
 )
 


### PR DESCRIPTION
# Summary of changes
Refactor Breadcrumb component to use the UG homepage as Breadcrumb home unless a page has its Domain Access set to something other than api.liveugconthub.uoguelph.dev alone

## Frontend
- Add `field_domain_access` to schema in `gatsby.node.js`
- Add `domains` to graphQL query and component calls in `page.js`
- Add `domains` prop to `breadcrumbs.js`
- Refactor Breadcrumb component code to create different trails depending on domain

## Backend
- Enable `domain--domain` in `admin/config/services/jsonapi/resource_types`

# Test Plan
- Go to https://tqtest.gatsbyjs.io/gceb3 and verify the Breadcrumb home icon goes to https://ovc.uoguelph.ca/
- Do the same for https://tqtest.gatsbyjs.io/cercidb3
- Go to https://tqtest.gatsbyjs.io/grce and verify Breadcrumb home is https://www.uoguelph.ca/
- Go to https://tqtest.gatsbyjs.io/grce/contact and verify the `GRCE` link in the breadcrumb trail takes you back to the GRCE homepage
- Go to https://tqtest.gatsbyjs.io/studentexperience/indigenous-advising and verify the `Home` link in the breadcrumb trail takes you to the Student Experience homepage. The Home icon, however, should go to https://www.uoguelph.ca/
- Go to https://tqtest.gatsbyjs.io/widget-options which is not in any menu. Only the page title should be in the breadcrumb trail and the home icon should go to https://www.uoguelph.ca/
