### PR TITLE
add class to prevent text overflow in the card

### DIFF
--- a/src/components/shared/stats.js
+++ b/src/components/shared/stats.js
@@ -16,7 +16,7 @@ function Stats (props) {
 					let statFAIcon = stat.field_font_awesome_icon ;
 
 					return <React.Fragment key={stat.drupal_id}>
-					<div className="uog-card">
+					<div className="uog-card text-break">
 						<dt>
 							{contentExists(statFAIcon) === true && <span className="fa-icon-colour"><i className={statFAIcon}>  </i></span>}
 							{statRange === true && statValueEnd !== null ? statValue + " - " + statValueEnd : statValue}


### PR DESCRIPTION
# Summary of changes
Added text-break class to prevent text from overflowing the cards in the Stats widget

## Frontend
Added text-break class to prevent text from overflowing the cards in the Stats widget

## Backend
n/a

# Test Plan
https://build-13c113d6-8cf5-41fa-a29a-9d74d5a68d7f.gtsb.io/

1. Go to /about and /choose-u-of-g and verify that the text in the Stats widget doesn't go beyond the card boundaries when resizing the browser window
