### PR TITLE
Remove Call to Action area from top of page

### DIFF
--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -311,26 +311,6 @@ const ProgramPage = ({data, location}) => {
             }
             <div className="container ft-container"><h1 className="fancy-title">{title}</h1></div>
         </div>
-
-        { /**** Blurb and Call to Action Button ****/ }
-        {ogDescription || callToActionData?.length>0 ? 
-        <div className="full-width-container bg-dark">
-            <div className="container">
-                <section className="row mx-2">
-                    {ogDescription && <div className="col-md-9"><p className="fs-2">{ogDescription}</p></div>}
-                    {callToActionData?.length>0 && 
-                    <div className={ogDescription ? "col-md-3" : "col-md-3 offset-md-9"}>
-                      <CallToAction 
-                        classes="btn btn-primary fs-1 me-4 p-4 w-100"
-                        href={callToActionData[0]?.node.field_call_to_action_link.uri} 
-                        goalEventCategory={callToActionData[0]?.node.relationships.field_call_to_action_goal?.name} 
-                        goalEventAction={callToActionData[0]?.node.relationships.field_call_to_action_goal?.field_goal_action}>
-                        {callToActionData[0]?.node.field_call_to_action_link.title}
-                      </CallToAction>
-                    </div>}
-                </section>
-            </div>
-        </div> : ``}
       
         <Breadcrumbs nodeID={nodeID} nodeTitle={title} domains={domains} />
 


### PR DESCRIPTION
# Summary of changes
Remove the dark grey Call to Action area from the top of the program page template

## Frontend
- Code to render the top Call to Action area deleted from `program-page.js`

## Backend
N/A

# Test Plan

Go to https://www.gatsbyjs.com/dashboard/2e86c058-a370-4898-ae51-9698cd178e8d/sites/fc8e90a4-54ce-4012-a5fc-3302f05a3d6d/deploys and, once the Pull Request build has finished, open it and review the program pages to ensure the dark grey area is gone and no unintended consequences have occurred as a result.

