### PR TITLE
Add widgets to Program content type

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -106,7 +106,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       | taxonomy_term__testimonial_type
 
     union widgetParagraphUnion =
-      paragraph__call_to_action
+      paragraph__block_widget
       | paragraph__events_widget
       | paragraph__general_text
       | paragraph__lead_paragraph
@@ -120,7 +120,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       | paragraph__accordion_section
 
     union widgetSectionParagraphUnion =
-      paragraph__call_to_action
+      paragraph__block_widget
       | paragraph__general_text
       | paragraph__lead_paragraph
       | paragraph__link_item
@@ -171,6 +171,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       alt: String
     }
     
+
     type media__image implements Node {
       drupal_id: String
       name: String
@@ -423,7 +424,14 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type paragraph__accordion_sectionRelationships implements Node {
       field_accordion_block_elements: [paragraph__accordion_block] @link(from: "field_accordion_block_elements___NODE")
-    } 
+    }
+    type paragraph__block_widget implements Node {
+      drupal_id: String
+      relationships: paragraph__block_widgetRelationships
+    }
+    type paragraph__block_widgetRelationships implements Node {
+      field_custom_block: block_content__basic
+    }
     type paragraph__button_widget implements Node {
       drupal_id: String
       field_button_link: FieldLink

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -389,6 +389,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_specializations: [taxonomy_term__specializations] @link(from: "field_specializations___NODE")
       field_tags: [taxonomy_term__tags] @link(from: "field_tags___NODE")
       field_prog_image: media__image @link(from: "field_prog_image___NODE")
+      field_widgets: [widgetParagraphUnion] @link(from:"field_widgets___NODE")
     }
     type node__testimonial implements Node {
       changed: Date

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -173,6 +173,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     
     type block_content__basic implements Node {
       drupal_id: String
+      info: String
       body: BodyFieldWithSummary
     }
     

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -171,7 +171,11 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       alt: String
     }
     
-
+    type block_content__basic implements Node {
+      drupal_id: String
+      body: BodyFieldWithSummary
+    }
+    
     type media__image implements Node {
       drupal_id: String
       name: String
@@ -427,10 +431,11 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type paragraph__block_widget implements Node {
       drupal_id: String
-      relationships: paragraph__block_widgetRelationships
+	  relationships: paragraph__block_widgetRelationships  
     }
     type paragraph__block_widgetRelationships implements Node {
-      field_custom_block: block_content__basic
+      field_custom_block: block_content__basic @link(from: "field_custom_block___NODE")
+      field_section_column: taxonomy_term__section_columns @link(from: "field_section_column___NODE")
     }
     type paragraph__button_widget implements Node {
       drupal_id: String

--- a/src/components/shared/blockWidget.js
+++ b/src/components/shared/blockWidget.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { graphql } from 'gatsby';
+
+const BlockWidget = (props) => {    
+    let processed = props.body.processed;
+    let textClass = props.textClass;
+    console.log(processed);
+    return <div {...(textClass !== `` ? {className:textClass} : {})} dangerouslySetInnerHTML={{__html: processed}}></div>    
+}
+
+BlockWidget.propTypes = {
+    processed: PropTypes.string,
+    textClass: PropTypes.string,
+}
+
+BlockWidget.defaultProps = {
+    processed: ``,
+    textClass: ``,
+}
+
+export default BlockWidget
+
+export const query = graphql`
+  fragment BlockWidgetParagraphFragment on paragraph__block_widget {
+    drupal_id
+    relationships {
+      field_custom_block {
+        body { 
+          processed
+        }
+      }
+    }
+  }
+`

--- a/src/components/shared/blockWidget.js
+++ b/src/components/shared/blockWidget.js
@@ -2,21 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { graphql } from 'gatsby';
 
+
 const BlockWidget = (props) => {    
-    let processed = props.body.processed;
-    let textClass = props.textClass;
-    console.log(processed);
-    return <div {...(textClass !== `` ? {className:textClass} : {})} dangerouslySetInnerHTML={{__html: processed}}></div>    
+    let processed = props.blockData.relationships.field_custom_block?.body.processed;    
+    return <div dangerouslySetInnerHTML={{__html: processed}}></div>  
 }
 
 BlockWidget.propTypes = {
-    processed: PropTypes.string,
-    textClass: PropTypes.string,
+    blockData: PropTypes.string,
 }
 
 BlockWidget.defaultProps = {
-    processed: ``,
-    textClass: ``,
+    blockData: ``,
 }
 
 export default BlockWidget
@@ -26,9 +23,13 @@ export const query = graphql`
     drupal_id
     relationships {
       field_custom_block {
+        info
         body { 
           processed
         }
+      }
+      field_section_column {
+        name
       }
     }
   }

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -13,8 +13,8 @@ import { ConditionalWrapper } from 'utils/ug-utils';
 // For the left column
 function renderPrimary(widget) {
     switch (widget?.__typename) {
-        case "paragraph_block_widget":
-            return <BlockWidget key={widget.drupal_id} processed={widget.field_custom_block.body.processed} />;
+        case "paragraph__block_widget":
+            return <BlockWidget key={widget.drupal_id} blockData={widget} />;
         case "paragraph__general_text":
             return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;
         case "paragraph__lead_paragraph":
@@ -46,8 +46,8 @@ function renderPrimary(widget) {
 //For the right column
 function renderSecondary(widget) {
     switch (widget?.__typename) {
-        case "paragraph_block_widget":
-            return <BlockWidget key={widget.drupal_id} processed={widget.field_custom_block.processed} />;
+        case "paragraph__block_widget":
+            return <BlockWidget key={widget.drupal_id} blockData={widget} />;
         case "paragraph__general_text":
             return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;                        
         case "paragraph__media_text":

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -60,7 +60,9 @@ function SectionWidgets (props) {
         let primary = [];
         let secondary = [];
         let primaryClass;
+        let secondaryClass;
         let allWidgets = props.pageData;
+        let sectionClasses = props.sectionClasses;
         
         allWidgets.forEach(widgetData => {
             let secCol = widgetData.relationships.field_section_column?.name;
@@ -72,7 +74,13 @@ function SectionWidgets (props) {
         })
 
         if (secondary.length > 0) {
-            primaryClass = "col-md-9";
+            if (sectionClasses === "col-md-6") {
+                primaryClass = "col-md-6";
+                secondaryClass = "col-md-6";
+            } else {
+                primaryClass = "col-md-9";
+                secondaryClass = "col-md-3";
+            }
         } else {
             primaryClass = "row";
         }
@@ -86,7 +94,7 @@ function SectionWidgets (props) {
                 </ConditionalWrapper>
             </div>
             {secondary.length > 0 && 
-            <div className="col-md-3">
+            <div className={secondaryClass}>
             {secondary.map(widget => {
                 return renderSecondary(widget)
             })}    
@@ -98,10 +106,11 @@ function SectionWidgets (props) {
 
 SectionWidgets.propTypes = {
     pageData: PropTypes.array,
-   
+    sectionClasses: PropTypes.string,
 }
 SectionWidgets.defaultProps = {
     pageData: ``,
+    sectionClasses: ``,
 }
 
 export default SectionWidgets

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { graphql } from 'gatsby';
+import BlockWidget from 'components/shared/blockWidget';
 import GeneralText from 'components/shared/generalText';
 import LeadPara from 'components/shared/leadPara';
 import LinksItems from 'components/shared/linksItems';
@@ -12,6 +13,8 @@ import { ConditionalWrapper } from 'utils/ug-utils';
 // For the left column
 function renderPrimary(widget) {
     switch (widget?.__typename) {
+        case "paragraph_block_widget":
+            return <BlockWidget key={widget.drupal_id} processed={widget.field_custom_block.body.processed} />;
         case "paragraph__general_text":
             return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;
         case "paragraph__lead_paragraph":
@@ -43,6 +46,8 @@ function renderPrimary(widget) {
 //For the right column
 function renderSecondary(widget) {
     switch (widget?.__typename) {
+        case "paragraph_block_widget":
+            return <BlockWidget key={widget.drupal_id} processed={widget.field_custom_block.processed} />;
         case "paragraph__general_text":
             return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;                        
         case "paragraph__media_text":
@@ -123,6 +128,9 @@ export const query = graphql`
     relationships {
       field_section_content {
         __typename
+        ... on paragraph__block_widget {
+            ...BlockWidgetParagraphFragment
+        }
         ... on paragraph__general_text {
             ...GeneralTextParagraphFragment
         }

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import Accordion from 'components/shared/accordion';
-import CtaPara from 'components/shared/ctaPara';
+import BlockWidget from 'components/shared/blockWidget';
 import Events from 'components/shared/events';
 import GeneralText from 'components/shared/generalText';
 import LeadPara from 'components/shared/leadPara';
@@ -15,8 +15,8 @@ const Widget = ({widget}) => {
     switch (widget?.__typename) {
         case "paragraph__accordion_section":
             return <Accordion pageData={widget} />;
-        case "paragraph__call_to_action":
-            return <CtaPara pageData={widget} />;
+        case "paragraph_block_widget":
+            return <BlockWidget processed={widget.field_custom_block.body.processed} />;
         case "paragraph__events_widget":
             return <Events eventData={widget} />;
         case "paragraph__general_text":
@@ -63,8 +63,8 @@ export const query = graphql`
     ... on paragraph__accordion_section {
         ...AccordionSectionParagraphFragment
     }
-    ... on paragraph__call_to_action {
-        ...CallToActionParagraphFragment
+    ... on paragraph__block_widget {
+        ...BlockWidgetParagraphFragment
     }
     ... on paragraph__events_widget {
         ...EventsParagraphFragment

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -42,7 +42,7 @@ const Widget = ({widget}) => {
             return (<>
 				{widget.field_section_title && <h2>{widget.field_section_title}</h2>}
 				<div key={widget.drupal_id} className="row mt-5">                    
-                    <SectionWidgets pageData={widget.relationships.field_section_content}/>
+                    <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>
 			</>);
         case "paragraph__section_tabs":

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -17,13 +17,14 @@ import NavTabContent from 'components/shared/navTabContent';
 import NewsGrid from 'components/shared/newsGrid';
 import Stats from 'components/shared/stats'
 import Testimonials from 'components/shared/testimonial';
-import Variants from 'components/shared/variants'; 
+import Variants from 'components/shared/variants';
+import Widget from 'components/shared/widget';
 import { sortLastModifiedDates } from 'utils/ug-utils';
 import { graphql } from 'gatsby';
 
-function renderProgramOverview(description) {
-    if (description) {
-        return <><h2>Program Overview</h2><div dangerouslySetInnerHTML={{ __html: description }} /></>
+function renderProgramOverview(overview) {
+    if (overview) {
+        return <><h2>Program Overview</h2><div dangerouslySetInnerHTML={{ __html: overview }} /></>
     }    
     return null;
 }
@@ -288,7 +289,8 @@ const ProgramPage = ({data, location}) => {
     const nodeID = progData.drupal_internal__nid;
     const title = progData.title;
     const acronym = (progData.relationships.field_program_acronym?.name);
-    const description = progData.field_program_overview?.processed;
+    const overview = progData.field_program_overview?.processed;
+    const widgets = progData.relationships?.field_widgets;
     const courseNotes = progData.field_course_notes?.processed;
 
     // set last modified date
@@ -317,8 +319,12 @@ const ProgramPage = ({data, location}) => {
         { /**** Program Overview ****/ }
         <div className="container page-container">
             <div className="row site-content">
-                <section className="content-area">
-                    {renderProgramOverview(description)}
+                {overview && <section className="content-area">
+                        {renderProgramOverview(overview)}
+                </section>}
+                { /**** Widgets content ****/} 
+                <section className="col-md-12">
+                    {widgets.map((widget, index) => <Widget widget={widget} key={index} />)} 
                 </section>
             </div>
         </div>
@@ -346,7 +352,7 @@ const ProgramPage = ({data, location}) => {
         <div className="container page-container apply-footer">
             <section className="row row-with-vspace site-content">
                 <div className="col-sm-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4 content-area">
-                    <h3><span>Are you ready to</span> Improve Life?</h3>
+                    <h3 className="text-dark text-center">Are you ready to Improve Life?</h3>
                     {callToActionData.map((cta, index) => (
                         <CallToAction key={index} href={cta.node.field_call_to_action_link.uri} 
                             goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name} 
@@ -468,6 +474,9 @@ export const query = graphql`query ($id: String) {
                 }
               }
             }
+          }
+          field_widgets {
+            ...FieldWidgetsFragment
           }
         }
       }

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -105,109 +105,108 @@ function CountProgramVariants(variantData) {
 
 function renderProgramInfoAccordion  (courseData, courseNotes, variantDataHeading, variantData, careerData, employerData) {
   
-  // accordion - Courses Item
- const programCourseItem = () => { 
-   if (courseNotes || courseData?.length>0) {
-      return (
-        <div className="accordion-item">
-          <h3 className="accordion-header" id="selectedCourses-heading">
-            <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#selectedCourses-courses" aria-expanded="false" aria-controls="selectedCourses-courses">
-              Selected Courses
-            </button>
-          </h3>
-          <div id="selectedCourses-courses" className="accordion-collapse collapse" aria-labelledby="selectedCourses-heading">
-            <div className="accordion-body">
-            {<Courses courseData={courseData} courseNotes={courseNotes} headingLevel="h4" />}
+    // accordion - Courses Item
+    const programCourseItem = () => { 
+        if (courseNotes || courseData?.length>0) {
+          return (
+            <div className="accordion-item">
+              <h3 className="accordion-header" id="selectedCourses-heading">
+                <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#selectedCourses-courses" aria-expanded="false" aria-controls="selectedCourses-courses">
+                  Selected Courses
+                </button>
+              </h3>
+              <div id="selectedCourses-courses" className="accordion-collapse collapse" aria-labelledby="selectedCourses-heading">
+                <div className="accordion-body">
+                {<Courses courseData={courseData} courseNotes={courseNotes} headingLevel="h4" />}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )
+          )
+        }
+        return null;
     }
-      return null;
-  }
 
-  // accordion - Variants Item
-  const programVariantItem = () => { 
-    if(variantDataHeading) {
-      return (
-        <div className="accordion-item">
-          <h3 className="accordion-header" id="programVariants-heading">
-            <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programVariants-variants" aria-expanded="false" aria-controls="programVariants-variants">
-              {variantDataHeading}
-            </button>
-          </h3>
-          <div id="programVariants-variants" className="accordion-collapse collapse" aria-labelledby="programVariants-heading">
-            <div className="accordion-body">
-              {<Variants variantData={variantData} />}
+    // accordion - Variants Item
+    const programVariantItem = () => { 
+        if(variantDataHeading) {
+          return (
+            <div className="accordion-item">
+              <h3 className="accordion-header" id="programVariants-heading">
+                <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programVariants-variants" aria-expanded="false" aria-controls="programVariants-variants">
+                  {variantDataHeading}
+                </button>
+              </h3>
+              <div id="programVariants-variants" className="accordion-collapse collapse" aria-labelledby="programVariants-heading">
+                <div className="accordion-body">
+                  {<Variants variantData={variantData} />}
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )
+          )
+        }
+        return null;
     }
-      return null;
-  }
 
-  // accordion - Careers Item
- const programCareersItem = () => { 
-   if (careerData?.length>0) {
-      return (
-        <div className="accordion-item">
-          <h3 className="accordion-header" id="programCareers-heading">
-            <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programCareers-careers" aria-expanded="false" aria-controls="programCareers-careers">
-              Careers
-            </button>
-          </h3>
-          <div id="programCareers-careers" className="accordion-collapse collapse" aria-labelledby="programCareers-heading">
-            <div className="accordion-body">
-            <Careers careerData={careerData} numColumns={3}/>
+    // accordion - Careers Item
+    const programCareersItem = () => { 
+        if (careerData?.length>0) {
+          return (
+            <div className="accordion-item">
+              <h3 className="accordion-header" id="programCareers-heading">
+                <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programCareers-careers" aria-expanded="false" aria-controls="programCareers-careers">
+                  Careers
+                </button>
+              </h3>
+              <div id="programCareers-careers" className="accordion-collapse collapse" aria-labelledby="programCareers-heading">
+                <div className="accordion-body">
+                <Careers careerData={careerData} numColumns={3}/>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )
+          )
+        }
+        return null; 
     }
-    return null; 
-  }
   
-  // Accordion - Employers Item
- const programEmployersItem = () => {
-   if (employerData?.length > 0) {
-      return (
-        <div className="accordion-item">
-          <h3 className="accordion-header" id="programEmployers-heading">
-            <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programEmployers-employers" aria-expanded="false" aria-controls="programEmployers-employers">
-              Employers
-            </button>
-          </h3>
-          <div id="programEmployers-employers" className="accordion-collapse collapse" aria-labelledby="programEmployers-heading">
-            <div className="accordion-body">
-            <Employers employerData={employerData} />
+    // accordion - Employers Item
+    const programEmployersItem = () => {
+        if (employerData?.length > 0) {
+          return (
+            <div className="accordion-item">
+              <h3 className="accordion-header" id="programEmployers-heading">
+                <button className="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#programEmployers-employers" aria-expanded="false" aria-controls="programEmployers-employers">
+                  Employers
+                </button>
+              </h3>
+              <div id="programEmployers-employers" className="accordion-collapse collapse" aria-labelledby="programEmployers-heading">
+                <div className="accordion-body">
+                <Employers employerData={employerData} />
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-      )
+          )
+        }
+        return null;
+    }
+    if (courseNotes || courseData?.length>0 || variantDataHeading || careerData?.length>0 ||employerData?.length > 0) {
+      return (
+            <div className="container page-container">
+              <section className="row row-with-vspace site-content">
+                  <div className="col-md-12 content-area">
+                  <h2>Program Information</h2>
+                    <div className="accordion" id="ProgramPageAccordion">
+                      {programCourseItem()}
+                      {programVariantItem()}
+                      {programCareersItem()}
+                      {programEmployersItem()}
+                    </div>
+                  </div>
+              </section>
+            </div>    
+        )
     }
     return null;
-  }
-if (courseNotes || courseData?.length>0 || variantDataHeading || careerData?.length>0 ||employerData?.length > 0) {
-  return (
-      <div className="container page-container">
-      <section className="row row-with-vspace site-content">
-          <div className="col-md-12 content-area">
-          <h2>Program Information</h2>
-            <div className="accordion" id="ProgramPageAccordion">
-              {programCourseItem()}
-              {programVariantItem()}
-              {programCareersItem()}
-              {programEmployersItem()}
-            </div>
-          </div>
-      </section>
-    </div>    
-)
 }
-return null;
-}
-
 
 function retrieveLastModifiedDates (content) {
     let dates = [];
@@ -222,7 +221,7 @@ function retrieveLastModifiedDates (content) {
 function prepareVariantHeading (variantData) {
     let labels = [];
 
-  // prepare variant data labels
+    // prepare variant data labels
     variantData.forEach((edge) => {
         if ((edge.__typename === "paragraph__program_variants") && (edge.relationships.field_variant_type !== null)) {
             labels.push(edge.relationships.field_variant_type.name);
@@ -313,9 +312,9 @@ const ProgramPage = ({data, location}) => {
                         {renderProgramOverview(overview)}
                 </section>}
                 { /**** Widgets content ****/} 
-                <section className="col-md-12">
+                {widgets && <section className="col-md-12">
                     {widgets.map((widget, index) => <Widget widget={widget} key={index} />)} 
-                </section>
+                </section>}
             </div>
         </div>
     
@@ -593,15 +592,6 @@ export const query = graphql`query ($id: String) {
           }
           field_widgets {
             __typename
-            ... on paragraph__call_to_action {
-              id
-              field_cta_title
-              field_cta_description
-              field_cta_primary_link {
-                title
-                uri
-              }
-            }
             ... on paragraph__lead_paragraph {
               id
               field_lead_paratext {
@@ -646,15 +636,6 @@ export const query = graphql`query ($id: String) {
               relationships {
                 field_section_content {
                   __typename
-                  ... on paragraph__call_to_action {
-                    id
-                    field_cta_title
-                    field_cta_description
-                    field_cta_primary_link {
-                      title
-                      uri
-                    }
-                  }
                   ... on paragraph__links_widget {
                     drupal_id
                     field_link_items_title


### PR DESCRIPTION
# Summary of changes
Make widgets available to the Program content type to offer more flexible layout options and add new widget for including custom blocks

## Frontend
- Widget component called in `program-page.js`
- `sectionWidgets.js` refactored to use section classes for differing column widths
- New component `blockWidget.js` for rendering the text of a Drupal custom block
- `gatsby-node.js` updated to include required schema for changes above

## Backend
- Add widgets to Program content type
- Add Block Widget paragraph type
- Enable block-related jsonapi

# Test Plan
Gatsby Cloud site: https://tqtest.gtsb.io/
Drupal multidev: https://progwidgets-chug.pantheonsite.io/

- Go to https://tqtest.gtsb.io/programs/bachelor-of-arts-and-sciences and verify it has a similar layout to the mockup at https://www.uoguelph.ca/dev/programs/bachelor-of-bio-resource-management
- Experiment with adding widgets to other programs 

## Known issues
- The current custom block for the Admission Requirements buttons uses Bootstrap 5 classes only. Additional classes will need to be added to the main U of G stylesheet to achieve the same look and feel from the mockup.
- Only `General Text`, `Media and Text`, and `Section` widgets are allowed for the Program content type at this time.
- Block widgets can only be added within a Section
