### PR TITLE
Space sections with margin-bottom instead of top

### DIFF
--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -41,7 +41,7 @@ const Widget = ({widget}) => {
         case "paragraph__section":
             return (<>
 				{widget.field_section_title && <h2>{widget.field_section_title}</h2>}
-				<div key={widget.drupal_id} className="row mt-5">                    
+				<div key={widget.drupal_id} className="row mb-5">                    
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>
 			</>);


### PR DESCRIPTION
# Summary of changes
Improved spacing between section widgets

## Frontend
Change `mt-5` to `mb-5` in `widgets.js` 

## Backend
N/A

# Test Plan

Once the PR build is complete on Gatsby Cloud, make sure pages that use sections still have proper spacing in wide and narrow viewports

