### PR TITLE
Remove home link functionality and unnecessary title (Temp Fix)

### DIFF
--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -94,10 +94,13 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                         <div className="col-sm-12">
                             <div className="site-breadcrumbs">          
                             <ol className="breadcrumb breadcrumb-right-tag">                                
-                                <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
-                                    {/* <a href={homeCrumbURL}> */}
-                                        <i aria-hidden="true" className="fa fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
-                                    {/* </a> */}
+                                <li key={homeCrumbURL + `home`} className="breadcrumb-item">
+                                    { homeCrumbURL === "https://www.uoguelph.ca"
+                                        ? <><i aria-hidden="true" className="fa fa-home"></i><span className="visually-hidden">{homeCrumb}</span></> 
+                                        : <a href={homeCrumbURL}>
+                                            <i aria-hidden="true" className="fa fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
+                                        </a>
+                                    }
                                 </li>
                                 {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
                                     <li key={topCrumbURL} className="breadcrumb-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -95,9 +95,9 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                             <div className="site-breadcrumbs">          
                             <ol className="breadcrumb breadcrumb-right-tag">                                
                                 <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
-                                    <a href={homeCrumbURL}>
+                                    {/* <a href={homeCrumbURL}> */}
                                         <i aria-hidden="true" className="fa fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
-                                    </a>
+                                    {/* </a> */}
                                 </li>
                                 {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
                                     <li key={topCrumbURL} className="breadcrumb-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -92,7 +92,7 @@ function SectionWidgets (props) {
         
         return (<>
             <div className={primaryClass}>
-                <ConditionalWrapper condition={secondary.length > 0} wrapper={children => <div className="row" title="primary sub-row when right column exists">{children}</div>}>
+                <ConditionalWrapper condition={secondary.length > 0} wrapper={children => <div className="row">{children}</div>}>
                 {primary && primary.map(widget => {
                     return renderPrimary(widget)
                 })}                


### PR DESCRIPTION
# Summary of changes
Remove home link functionality and unnecessary title.
This is just a temporary fix until we can confirm that the other fix works.

## Frontend
List all significant changes to Gatsby code

## Backend
List all significant changes to the Drupal site (e.g. new fields, content types, modules, etc)

# Test Plan

Insert steps. Include URLs of Gatsby Cloud test site and Drupal multidev.

