### PR TITLE
Updates for International

### DIFF
--- a/src/components/blocks/economic-impact/national-impact-stats.js
+++ b/src/components/blocks/economic-impact/national-impact-stats.js
@@ -24,7 +24,7 @@ const render = ({ title, stats }, colourOptions) => (
                 <Statistic.SolidCard 
                   background={colourOptions[index].background} 
                   colour={colourOptions[index].colour} 
-                  className="p-5" >
+                  className="p-5 h-100" >
                   <Statistic.Value><strong>{value}</strong></Statistic.Value>
                   <Statistic.Type>{type}</Statistic.Type>
                 </Statistic.SolidCard>

--- a/src/components/blocks/international/international-explore-grid.js
+++ b/src/components/blocks/international/international-explore-grid.js
@@ -7,7 +7,7 @@ import styled from "styled-components"
 const yaml = require('js-yaml');
 
 const Background = styled(PageContainer.FullWidth)`
-  background: #f1f5f9;
+  background: #F4F7FA;
 `
 const HeadingIcon = styled.i`
   color: ${props => (props.iconColour ?? "#000000")};

--- a/src/components/blocks/international/international-explore-grid.js
+++ b/src/components/blocks/international/international-explore-grid.js
@@ -31,7 +31,7 @@ const render = ({ field_yaml_map }) => {
             <Row className="row-cols-1 row-cols-md-3 g-4 mt-0">
                 {yamlMap.content.map(({title, body_html, icon, icon_color}, index) => 
                     <Col key={`international-explore-grid-${index}`} className="pe-4">
-                      <h3 className="h4 text-dark mt-0 d-flex align-items-start"><HeadingIcon className={`${icon} pe-3`} iconColour={icon_color} /> {title}</h3>
+                      <h3 className="h4 text-dark mt-0 d-flex align-items-start"><HeadingIcon aria-hidden={true} className={`${icon} pe-3`} iconColour={icon_color} /> {title}</h3>
                       <div dangerouslySetInnerHTML={{__html: body_html}}></div>
                     </Col>
                 )}

--- a/src/components/blocks/international/international-explore-grid.js
+++ b/src/components/blocks/international/international-explore-grid.js
@@ -31,7 +31,7 @@ const render = ({ field_yaml_map }) => {
             <Row className="row-cols-1 row-cols-md-3 g-4 mt-0">
                 {yamlMap.content.map(({title, body_html, icon, icon_color}, index) => 
                     <Col key={`international-explore-grid-${index}`} className="pe-4">
-                      <h3 className="h4 text-dark mt-0"><HeadingIcon className={`${icon} pe-2`} iconColour={icon_color} /> {title}</h3>
+                      <h3 className="h4 text-dark mt-0 d-flex align-items-start"><HeadingIcon className={`${icon} pe-3`} iconColour={icon_color} /> {title}</h3>
                       <div dangerouslySetInnerHTML={{__html: body_html}}></div>
                     </Col>
                 )}

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -34,15 +34,13 @@ const render = ({ field_yaml_map, relationships }) => {
     
     return (
         <>
-            <h2>{yamlMap.title}</h2>
-            <Row>
-              <Col md={9} className="pe-5">
-                <Lead dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
-              </Col>
-              <Col md={3}>
-                <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>
-              </Col>
-            </Row>
+          <h2>{yamlMap.title}</h2>
+          <Col md={9} className="pe-5">
+            <Lead dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
+          </Col>
+          <Col md={3}>
+            <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>
+          </Col>
         </>
 )}
 

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -22,7 +22,7 @@ const render = ({ field_yaml_map, relationships }) => {
     let yamlMap;
     let yamlFiles = {};
     relationships.field_yaml_files.forEach(file => {
-      yamlFiles[file.path.alias] = file.relationships.field_media_image.gatsbyImage;
+      yamlFiles[file.path.alias] = file.relationships.field_media_image.localFile;
     });
 
     try {
@@ -59,11 +59,11 @@ const query = graphql`
           name
           relationships {
             field_media_image {
-              gatsbyImage(
-                width: 1000
-                placeholder: BLURRED
-                layout: CONSTRAINED
-              )
+              localFile {
+                childImageSharp {
+                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                }
+              }
             }
           }
           path {

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -2,6 +2,7 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { Row, Col } from "react-bootstrap";
 import styled from "styled-components"
+import PageContainer from 'components/shared/pageContainer'
 
 const yaml = require('js-yaml');
 
@@ -33,15 +34,19 @@ const render = ({ field_yaml_map, relationships }) => {
     }
     
     return (
-        <>
-          <h2>{yamlMap.title}</h2>
-          <Col md={9} className="pe-5">
-            <Lead dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
-          </Col>
-          <Col md={3}>
-            <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>
-          </Col>
-        </>
+      <PageContainer.SiteContent>
+        <PageContainer.ContentArea>
+          <Row className="mt-5">
+            <h2>{yamlMap.title}</h2>
+            <Col md={9} className="pe-5">
+              <Lead dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
+            </Col>
+            <Col md={3}>
+              <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>
+            </Col>
+          </Row>
+        </PageContainer.ContentArea>
+      </PageContainer.SiteContent>
 )}
 
 

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -22,7 +22,7 @@ const render = ({ field_yaml_map, relationships }) => {
     let yamlMap;
     let yamlFiles = {};
     relationships.field_yaml_files.forEach(file => {
-      yamlFiles[file.path.alias] = file.relationships.field_media_image.localFile;
+      yamlFiles[file.path.alias] = file.relationships.field_media_image.gatsbyImage;
     });
 
     try {
@@ -33,7 +33,7 @@ const render = ({ field_yaml_map, relationships }) => {
     }
     
     return (
-        <section>
+        <>
             <h2>{yamlMap.title}</h2>
             <Row>
               <Col md={9} className="pe-5">
@@ -43,7 +43,7 @@ const render = ({ field_yaml_map, relationships }) => {
                 <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>
               </Col>
             </Row>
-        </section>
+        </>
 )}
 
 
@@ -59,11 +59,11 @@ const query = graphql`
           name
           relationships {
             field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
-                }
-              }
+              gatsbyImage(
+                width: 1000
+                placeholder: BLURRED
+                layout: CONSTRAINED
+              )
             }
           }
           path {

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -36,7 +36,7 @@ const render = ({ field_yaml_map, relationships }) => {
     return (
       <PageContainer.SiteContent>
         <PageContainer.ContentArea>
-          <Row className="mt-5">
+          <Row className="mt-sm-5">
             <h2>{yamlMap.title}</h2>
             <Col md={9} className="pe-5">
               <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -39,7 +39,7 @@ const render = ({ field_yaml_map, relationships }) => {
           <Row className="mt-5">
             <h2>{yamlMap.title}</h2>
             <Col md={9} className="pe-5">
-              <Lead dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
+              <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
             </Col>
             <Col md={3}>
               <Button href={yamlMap.link.url} className="btn btn-primary text-uppercase text-center">{yamlMap.link.title}</Button>

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -26,7 +26,7 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
   let yamlMap;
   let yamlFiles = {};
   relationships.field_yaml_files.forEach(file => {
-    yamlFiles[file.path.alias] = file.relationships.field_media_image.gatsbyImage;
+    yamlFiles[file.path.alias] = file.relationships.field_media_image.localFile;
   });
 
   try {
@@ -80,12 +80,11 @@ const query = graphql`
           name
           relationships {
             field_media_image {
-              gatsbyImage(
-                width: 1400
-                height: 190
-                placeholder: BLURRED
-                layout: CONSTRAINED
-              ) 
+              localFile {
+                childImageSharp {
+                  gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
+                }
+              }
             }
           }
           path {

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -2,7 +2,7 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { getImage } from "gatsby-plugin-image"
 import Overlay from "components/shared/overlay"
-import { Container, Col, Row } from "react-bootstrap"
+import { Col, Row } from "react-bootstrap"
 import PageContainer from 'components/shared/pageContainer'
 import Statistic from "components/shared/statistic"
 import styled from 'styled-components'
@@ -11,9 +11,9 @@ const yaml = require('js-yaml');
 
 const Shadow = styled.p`
   text-shadow: 0px 0px 4px #ffffff;
-`
-const Gradient = styled(PageContainer.FullWidth)`
-  background: linear-gradient(to right,#000 0%,#000 60%,#69A3B9 60%,#69A3B9 100%);
+  &:hover, &:focus {
+    text-shadow: none;
+  }
 `
 const colourOptions = [
   {background: "var(--black)", colour: "#FFFFFF"},
@@ -26,7 +26,7 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
   let yamlMap;
   let yamlFiles = {};
   relationships.field_yaml_files.forEach(file => {
-    yamlFiles[file.path.alias] = file.relationships.field_media_image.localFile;
+    yamlFiles[file.path.alias] = file.relationships.field_media_image.gatsbyImage;
   });
 
   try {
@@ -38,20 +38,19 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
   
   return (
     <>
-        <div className="d-flex flex-column bg-light">
+        <div className="d-flex flex-column">
           <Overlay.GatsbyImage gatsbyImageData={getImage(yamlFiles[yamlMap.background_image.src])} alt={yamlMap.background_image.alt}>
             <PageContainer>
               <Row className="h-100 w-100 p-5 justify-content-center align-items-center">
                 <div className="text-center"> 
-                  <p className="display-2 text-dark"><strong>{yamlMap.title}</strong></p>
+                  <h2 className="display-2 text-dark">{yamlMap.title}</h2>
                   <Shadow><a href={yamlMap.link.url}>{yamlMap.link.title}</a></Shadow>
                 </div>
               </Row>
             </PageContainer>
           </Overlay.GatsbyImage>
         </div>
-      <Gradient className="d-flex flex-column">
-        <Container className="page-container p-0">
+      <div className="d-flex flex-column">
             <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
                 {yamlMap.stats.map(({value, type}, index) => 
                   <Col key={`international-stat-${index}`}>
@@ -65,8 +64,7 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
                   </Col>
                 )}
             </Statistic>
-        </Container>
-      </Gradient>
+      </div>
     </>
   )}
 
@@ -82,11 +80,12 @@ const query = graphql`
           name
           relationships {
             field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
-                }
-              }
+              gatsbyImage(
+                width: 1400
+                height: 190
+                placeholder: BLURRED
+                layout: CONSTRAINED
+              ) 
             }
           }
           path {

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -37,35 +37,35 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
   }
   
   return (
-    <>
+    <PageContainer.SiteContent>
+      <PageContainer.ContentArea>
+          <div className="d-flex flex-column">
+            <Overlay.GatsbyImage gatsbyImageData={getImage(yamlFiles[yamlMap.background_image.src])} alt={yamlMap.background_image.alt}>
+                <Row className="h-100 w-100 p-5 justify-content-center align-items-center">
+                  <div className="text-center"> 
+                    <h2 className="display-2 text-dark">{yamlMap.title}</h2>
+                    <Shadow><a href={yamlMap.link.url}>{yamlMap.link.title}</a></Shadow>
+                  </div>
+                </Row>
+            </Overlay.GatsbyImage>
+          </div>
         <div className="d-flex flex-column">
-          <Overlay.GatsbyImage gatsbyImageData={getImage(yamlFiles[yamlMap.background_image.src])} alt={yamlMap.background_image.alt}>
-            <PageContainer>
-              <Row className="h-100 w-100 p-5 justify-content-center align-items-center">
-                <div className="text-center"> 
-                  <h2 className="display-2 text-dark">{yamlMap.title}</h2>
-                  <Shadow><a href={yamlMap.link.url}>{yamlMap.link.title}</a></Shadow>
-                </div>
-              </Row>
-            </PageContainer>
-          </Overlay.GatsbyImage>
+              <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
+                  {yamlMap.stats.map(({value, type}, index) => 
+                    <Col key={`international-stat-${index}`}>
+                      <Statistic.SolidCard 
+                        background={colourOptions[index].background} 
+                        colour={colourOptions[index].colour} 
+                        className="px-5 pt-5 pb-3" >
+                        <Statistic.Value fontsize="3.25rem"><strong>{value}</strong></Statistic.Value>
+                        <Statistic.Type>{type}</Statistic.Type>
+                      </Statistic.SolidCard>
+                    </Col>
+                  )}
+              </Statistic>
         </div>
-      <div className="d-flex flex-column">
-            <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
-                {yamlMap.stats.map(({value, type}, index) => 
-                  <Col key={`international-stat-${index}`}>
-                    <Statistic.SolidCard 
-                      background={colourOptions[index].background} 
-                      colour={colourOptions[index].colour} 
-                      className="px-5 pt-5 pb-3" >
-                      <Statistic.Value fontsize="3.25rem"><strong>{value}</strong></Statistic.Value>
-                      <Statistic.Type>{type}</Statistic.Type>
-                    </Statistic.SolidCard>
-                  </Col>
-                )}
-            </Statistic>
-      </div>
-    </>
+      </PageContainer.ContentArea>
+    </PageContainer.SiteContent>
   )}
 
 const query = graphql`

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -50,18 +50,18 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
             </Overlay.GatsbyImage>
           </div>
         <div className="d-flex flex-column">
-              <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
-                  {yamlMap.stats.map(({value, type}, index) => 
-                      <Statistic.SolidCard 
-                        key={`international-stat-${index}`}
-                        background={colourOptions[index].background} 
-                        colour={colourOptions[index].colour} 
-                        className="px-5 pt-5 pb-3" >
-                        <Statistic.Value fontsize="3.25rem"><strong>{value}</strong></Statistic.Value>
-                        <Statistic.Type>{type}</Statistic.Type>
-                      </Statistic.SolidCard>
-                  )}
-              </Statistic>
+          <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
+            {yamlMap.stats.map(({value, type}, index) => 
+              <Statistic.SolidCard 
+                key={`international-stat-${index}`}
+                background={colourOptions[index].background} 
+                colour={colourOptions[index].colour} 
+                className="px-5 pt-5 pb-3 col" >
+                <Statistic.Value fontsize="3.25rem"><strong>{value}</strong></Statistic.Value>
+                <Statistic.Type>{type}</Statistic.Type>
+              </Statistic.SolidCard>
+            )}
+          </Statistic>
         </div>
       </PageContainer.ContentArea>
     </PageContainer.SiteContent>

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -2,7 +2,7 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { getImage } from "gatsby-plugin-image"
 import Overlay from "components/shared/overlay"
-import { Col, Row } from "react-bootstrap"
+import { Row } from "react-bootstrap"
 import PageContainer from 'components/shared/pageContainer'
 import Statistic from "components/shared/statistic"
 import styled from 'styled-components'
@@ -52,15 +52,14 @@ const render = ({ field_yaml_map, relationships }, colourOptions) => {
         <div className="d-flex flex-column">
               <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
                   {yamlMap.stats.map(({value, type}, index) => 
-                    <Col key={`international-stat-${index}`}>
                       <Statistic.SolidCard 
+                        key={`international-stat-${index}`}
                         background={colourOptions[index].background} 
                         colour={colourOptions[index].colour} 
                         className="px-5 pt-5 pb-3" >
                         <Statistic.Value fontsize="3.25rem"><strong>{value}</strong></Statistic.Value>
                         <Statistic.Type>{type}</Statistic.Type>
                       </Statistic.SolidCard>
-                    </Col>
                   )}
               </Statistic>
         </div>

--- a/src/components/blocks/international/international-talk-current-student.js
+++ b/src/components/blocks/international/international-talk-current-student.js
@@ -2,15 +2,8 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { Row, Col } from "react-bootstrap";
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
-import styled from "styled-components";
 
 const yaml = require('js-yaml');
-
-const Wrapper = styled(Row)`
-  @media only screen and (min-width: 768px) {
-    margin: 8rem 0;
-  }
-`
 
 const render = ({ field_yaml_map, relationships }) => {
     let yamlMap;
@@ -27,7 +20,7 @@ const render = ({ field_yaml_map, relationships }) => {
     }
     
     return (
-      <Wrapper>
+      <Row className="my-sm-5">
         <Col md={7}>
           <GatsbyImage image={getImage(yamlFiles[yamlMap.image.src])} alt={yamlMap.image.alt} />
         </Col>
@@ -36,7 +29,7 @@ const render = ({ field_yaml_map, relationships }) => {
           <p>{yamlMap.body}</p>
           <a href={yamlMap.link.url}>{yamlMap.link.title}</a>
         </Col>
-      </Wrapper>
+      </Row>
 )}
 
 

--- a/src/components/blocks/international/international-talk-current-student.js
+++ b/src/components/blocks/international/international-talk-current-student.js
@@ -7,7 +7,9 @@ import styled from "styled-components";
 const yaml = require('js-yaml');
 
 const Wrapper = styled(Row)`
-  margin: 8rem 0;
+  @media only screen and (min-width: 768px) {
+    margin: 8rem 0;
+  }
 `
 
 const render = ({ field_yaml_map, relationships }) => {

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -3,6 +3,7 @@ import { StaticQuery, graphql } from "gatsby"
 import { Row, Col } from "react-bootstrap";
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import styled from "styled-components"
+import PageContainer from 'components/shared/pageContainer'
 
 const yaml = require('js-yaml');
 const MediaCardBody = styled.div`
@@ -28,27 +29,29 @@ const render = ({ field_yaml_map, relationships }) => {
     }
     
     return (
-        <section>
-            <h2>{yamlMap.title}</h2>
-            <Row className="row-cols-1 row-cols-md-3 g-4">
-                {yamlMap.cards.map(({title, text, image, links}, index) => 
-                    <Col key={`international-explore-${index}`}>
-                        <div className="card h-100 border-0">
-                            <GatsbyImage image={getImage(yamlFiles[image.src])} alt={image.alt} className="card-img-bottom" />
-                            <MediaCardBody className="card-body">
-                                <MediaTitle>{title}</MediaTitle>
-                                <p>{text}</p>
-                                <div className="d-grid d-md-block gap-2">
-                                    {links.map(({title, url}, index) => 
-                                        <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
-                                    )}
-                                </div>
-                            </MediaCardBody>
-                        </div>
-                    </Col>
-                )}
-            </Row>
-        </section>
+      <PageContainer.SiteContent>
+        <PageContainer.ContentArea>
+          <h2>{yamlMap.title}</h2>
+          <Row className="row-cols-1 row-cols-md-3 g-4">
+              {yamlMap.cards.map(({title, text, image, links}, index) => 
+                  <Col key={`international-explore-${index}`}>
+                      <div className="card h-100 border-0">
+                          <GatsbyImage image={getImage(yamlFiles[image.src])} alt={image.alt} className="card-img-bottom" />
+                          <MediaCardBody className="card-body">
+                              <MediaTitle>{title}</MediaTitle>
+                              <p>{text}</p>
+                              <div className="d-grid d-md-block gap-2">
+                                  {links.map(({title, url}, index) => 
+                                      <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                  )}
+                              </div>
+                          </MediaCardBody>
+                      </div>
+                  </Col>
+              )}
+          </Row>
+        </PageContainer.ContentArea>
+      </PageContainer.SiteContent>
 )}
 
 

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -17,7 +17,7 @@ function MediaText (props) {
     const mediaRelationships = props.widgetData.relationships.field_media_text_media?.relationships;
 
     const imageURL = mediaRelationships?.field_media_image?.localFile;	
-    const imageAlt = props.widgetData.relationships.field_media_text_media.field_media_image?.alt ?? "";
+    const imageAlt = props.widgetData.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
     
     const videoTitle = props.widgetData.relationships.field_media_text_media?.name;

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -17,7 +17,7 @@ function MediaText (props) {
     const mediaRelationships = props.widgetData.relationships.field_media_text_media?.relationships;
 
     const imageURL = mediaRelationships?.field_media_image?.localFile;	
-    const imageAlt = mediaRelationships?.field_media_image?.alt ?? "";
+    const imageAlt = props.widgetData.relationships.field_media_text_media.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
     
     const videoTitle = props.widgetData.relationships.field_media_text_media?.name;

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -52,7 +52,7 @@ Statistic.BorderCard = ({border, children, className=""}) => (
 )
 
 Statistic.SolidCard = ({background, colour, children, className=""}) => (
-    <StatSolidCard background={background} colour={colour} className={`${className} h-100 align-self-stretch`}>
+    <StatSolidCard background={background} colour={colour} className={`${className} align-self-stretch`}>
       {children}
     </StatSolidCard>
 )

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -52,7 +52,7 @@ Statistic.BorderCard = ({border, children, className=""}) => (
 )
 
 Statistic.SolidCard = ({background, colour, children, className=""}) => (
-    <StatSolidCard background={background} colour={colour} className={`${className} align-self-stretch`}>
+    <StatSolidCard background={background} colour={colour} className={`${className} h-100 align-self-stretch`}>
       {children}
     </StatSolidCard>
 )

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -3,7 +3,6 @@ import styled from "styled-components"
 
 const StatCard = styled.div`
   background: var(--uog-blue-muted);
-  flex: 1 0;
   padding: 1.25rem;
   min-width: 25%;
   word-wrap: break-word;

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -53,7 +53,7 @@ Statistic.BorderCard = ({border, children, className=""}) => (
 )
 
 Statistic.SolidCard = ({background, colour, children, className=""}) => (
-    <StatSolidCard background={background} colour={colour} className={`${className} h-100`}>
+    <StatSolidCard background={background} colour={colour} className={`${className} align-self-stretch`}>
       {children}
     </StatSolidCard>
 )

--- a/src/data/block/international/international-explore-lead.yml
+++ b/src/data/block/international/international-explore-lead.yml
@@ -3,4 +3,4 @@ title: Improving Lives Starts Here
 body_html: <p>As an international student at the University of Guelph, learn and work side by side with expert professors, researchers, and fellow students from all across the world to Improve Life through engaged learning inside and outside the classroom, unique internships and co-op opportunities. Support and information for all your needs as an international student at U of G are available at your fingertips. </p>
 link:
   title: Apply Now
-  url: https://admission.uoguelph.ca/chat-international-u-g-student-and-staff
+  url: https://admission.uoguelph.ca/admission-information/international/international-application-forms

--- a/src/data/block/international/international-explore-lead.yml
+++ b/src/data/block/international/international-explore-lead.yml
@@ -1,6 +1,6 @@
 id: international_explore_lead
 title: Improving Lives Starts Here
-body_html: <p>Join the <strong>1700+ international students</strong> from all over the world as you learn and grow with U of G's professors, researchers, and fellow students.</p>
+body_html: <p>As an international student at the University of Guelph, learn and work side by side with expert professors, researchers, and fellow students from all across the world to Improve Life through engaged learning inside and outside the classroom, unique internships and co-op opportunities. Support and information for all your needs as an international student at U of G are available at your fingertips. </p>
 link:
   title: Apply Now
   url: https://admission.uoguelph.ca/chat-international-u-g-student-and-staff

--- a/src/data/block/international/international-explore-things-to-know.yml
+++ b/src/data/block/international/international-explore-things-to-know.yml
@@ -1,31 +1,31 @@
 id: international_explore_things_to_know
 title: Things You Should Know About the City of Guelph
 cards:
-  - title: Airports
-    text: Less then an hour away from Toronto Pearson International Airport and Billy Bishop Airport.
-    image: 
-      src: /international/images/airport-pexels-1008155.jpg
-      alt: Person walking through airport terminal
-    links:
-      - title: Pearson
-        url: https://www.google.com/maps/dir/Toronto+Pearson+International+Airport+(YYZ),+6301+Silver+Dart+Dr,+Mississauga,+ON+L5P+1B2/University+of+Guelph,+50+Stone+Rd+E,+Guelph,+ON+N1G+2W1,+Canada/@43.6186947,-80.1616917,10z/data=!4m14!4m13!1m5!1m1!1s0x882b394ac02dd491:0xb41d5de9c4030ec5!2m2!1d-79.6248197!2d43.6777176!1m5!1m1!1s0x882b9b3c1d38a0b7:0x8feb99e54d4013c7!2m2!1d-80.2261804!2d43.5327217!3e3
-      - title: Billy Bishop
-        url: https://www.google.com/maps/dir/Billy+Bishop+Toronto+City+Airport,+2+Eireann+Quay,+Toronto,+ON+M5V+1A1/University+of+Guelph,+50+Stone+Rd+E,+Guelph,+ON+N1G+2W1,+Canada/@43.578702,-80.0932519,10z/data=!4m14!4m13!1m5!1m1!1s0x882b35235593a107:0x42881882560c474!2m2!1d-79.3959577!2d43.6284819!1m5!1m1!1s0x882b9b3c1d38a0b7:0x8feb99e54d4013c7!2m2!1d-80.2261804!2d43.5327217!3e3
-  - title: Hikes and Trails
-    text: Guelph is home to many of Ontario’s best Hikes and Trails, one of which is right on campus!
-    image: 
-      src: /international/images/trail-pexels-6039195.jpg
-      alt: Hiking trail
-    links:
-      - title: Best Trails in Guelph
-        url: https://www.alltrails.com/canada/ontario/guelph
-  - title: Restaurants
-    text: From fine dining to chaep eats, Guelph has the best selection of restaurants to satisfy your taste buds!
-    image: 
-      src: /international/images/food-pexels-9961870.jpg
-      alt: People eating from food platter
-    links:
-      - title: Restaurants in Guelph
-        url: https://www.tripadvisor.ca/Restaurants-g154989-Guelph_Ontario.html
+    - title: Airports
+      text: Less then an hour away from Toronto Pearson International Airport and Billy Bishop Airport.
+      image: 
+        src: /images/airport-pexels-1008155.jpg
+        alt: Person walking through airport terminal
+      links:
+        - title: Pearson
+          url: https://www.google.com/maps/dir/Toronto+Pearson+International+Airport+(YYZ),+6301+Silver+Dart+Dr,+Mississauga,+ON+L5P+1B2/University+of+Guelph,+50+Stone+Rd+E,+Guelph,+ON+N1G+2W1,+Canada/@43.6186947,-80.1616917,10z/data=!4m14!4m13!1m5!1m1!1s0x882b394ac02dd491:0xb41d5de9c4030ec5!2m2!1d-79.6248197!2d43.6777176!1m5!1m1!1s0x882b9b3c1d38a0b7:0x8feb99e54d4013c7!2m2!1d-80.2261804!2d43.5327217!3e3
+        - title: Billy Bishop
+          url: https://www.google.com/maps/dir/Billy+Bishop+Toronto+City+Airport,+2+Eireann+Quay,+Toronto,+ON+M5V+1A1/University+of+Guelph,+50+Stone+Rd+E,+Guelph,+ON+N1G+2W1,+Canada/@43.578702,-80.0932519,10z/data=!4m14!4m13!1m5!1m1!1s0x882b35235593a107:0x42881882560c474!2m2!1d-79.3959577!2d43.6284819!1m5!1m1!1s0x882b9b3c1d38a0b7:0x8feb99e54d4013c7!2m2!1d-80.2261804!2d43.5327217!3e3
+    - title: Hikes and Trails
+      text: Guelph is home to many of Ontario’s best Hikes and Trails, one of which is right on campus!
+      image: 
+        src: /images/trail-pexels-6039195.jpg
+        alt: Hiking trail
+      links:
+        - title: Best Trails in Guelph
+          url: https://www.alltrails.com/canada/ontario/guelph
+    - title: Restaurants
+      text: From fine dining to chaep eats, Guelph has the best selection of restaurants to satisfy your taste buds!
+      image: 
+        src: /images/food-pexels-9961870.jpg
+        alt: People eating from food platter
+      links:
+        - title: Restaurants in Guelph
+          url: https://www.tripadvisor.ca/Restaurants-g154989-Guelph_Ontario.html
 
-    
+      

--- a/src/data/block/international/international-stats-global-impact.yml
+++ b/src/data/block/international/international-stats-global-impact.yml
@@ -1,7 +1,7 @@
 id: international_stats_global_impact
 title: U of G Places 16th in Global Impact in International Ranking
 background_image:
-  src: /international/images/johnston3-stat.jpg
+  src: /images/johnston3-stat.jpg
   alt: "Johnston Hall"
 link:
   title: "Learn More: Read the Full Article!"

--- a/src/data/block/international/international-talk-current-student.yml
+++ b/src/data/block/international/international-talk-current-student.yml
@@ -2,7 +2,7 @@ id: international_talk_current_student
 title: Talk to a Current International Student
 body: Don’t just take it from us – hear from one of our many International Students on their experiences with Guelph, integrating into U of G life, and much more.
 image:
-  src: /international/images/unibuddy.jpg
+  src: /images/unibuddy.png
   alt: Smiling students
 link:
   title: Start Chatting Today!


### PR DESCRIPTION
# Summary of changes
- Updates for International

## Frontend
- Put stats in PageContainer (instead of full width)
- Add PageContainer to any international components that are not full width (instead of placing them in the section widget which affects the spacing by adding too many nested rows)
- Add aria-hidden to icons
- Align text beside icons so longer titles do not wrap under the icon
- Update structure of definition lists for accessibility
- Update colour contrast for accessibility (blue links on Explore U of G section)
- Update margins on talk to a current student section

## Backend
- N/A

# Test Plan
- ~Visit https://build-9ccd564b-6b69-461a-b651-13c29e057d2d.gtsb.io/explore-university-of-guelph-international~
- Updated Build: https://build-9784f134-ed45-4388-a076-5f7e8dfc87a4.gtsb.io/explore-university-of-guelph-international

