### PR TITLE
A11y fixes on Impact Report (DL and colour contrast)

### DIFF
--- a/src/components/blocks/economic-impact/anchors.js
+++ b/src/components/blocks/economic-impact/anchors.js
@@ -5,11 +5,11 @@ const render = ({ title, anchors }) => (
     <>
         <h4>{title}</h4>
         <div id="menubox1">
-            <ul className="menu list-group">
-                {anchors.map(({title, url}, index) =>
-                    <li key={`anchor-${title}-${index}`} className="list-group-item"><a href={url}>{title}</a></li>
-                )}
-            </ul>
+          <ul className="menu list-group">
+            {anchors.map(({title, url}, index) =>
+                <li key={`anchor-${title}-${index}`} className="list-group-item"><a href={url}>{title}</a></li>
+            )}
+          </ul>
         </div>
     </>
 )

--- a/src/components/blocks/economic-impact/community-impact-campus-stats.js
+++ b/src/components/blocks/economic-impact/community-impact-campus-stats.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
-import { Container, Row } from "react-bootstrap"
 import Statistic from "components/shared/statistic"
 
 const colourOptions = [
@@ -11,28 +10,25 @@ const colourOptions = [
   ];
 
 const render = ({ title, stats }) => (
-  <Container>
-    <Row className="content-area">
+  <div className="content-area">
       <h3 className="h4">{title}</h3>
-      <Statistic className="row mb-5 g-4">
+      <Statistic.Grid columns="3" className="mb-5 gap-4">
           {stats.map(({value, type, image, link}, index) =>
-            <div key={`community-stat-campuses-${index}`} className="col-lg">
-                <Statistic.SolidCard  
-                    background={colourOptions[index].background} 
-                    colour={colourOptions[index].colour}
-                    className="pt-4 pb-0 px-0 h-100 card border-0" >
-                    <Statistic.Value><strong>{value}</strong></Statistic.Value>
-                    {link ? 
-                      <Statistic.Type className="mb-4 px-5"><a href={link.url} className="fs-3 text-white">{type}</a></Statistic.Type>
-                      : <Statistic.Type className="mb-4 px-5">{type}</Statistic.Type>
-                    }
-                    <GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" />
-                </Statistic.SolidCard>
-              </div>
+            <Statistic.SolidCard  
+              key={`community-stat-campuses-${index}`} 
+              background={colourOptions[index].background} 
+              colour={colourOptions[index].colour}
+              className="pt-4 pb-0 px-0 h-100 card border-0" >
+              <Statistic.Value><strong>{value}</strong></Statistic.Value>
+              {link ? 
+                <Statistic.Type className="mb-4 px-5"><a href={link.url} className="fs-3 text-white">{type}</a></Statistic.Type>
+                : <Statistic.Type className="mb-4 px-5">{type}</Statistic.Type>
+              }
+              <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd>
+            </Statistic.SolidCard>
           )}
-      </Statistic>
-    </Row>
-  </Container>
+      </Statistic.Grid>
+  </div>
 )
 
 const query = graphql`

--- a/src/components/blocks/economic-impact/community-impact.js
+++ b/src/components/blocks/economic-impact/community-impact.js
@@ -21,17 +21,15 @@ const render = ({ title, intro, stats }) => (
               {intro.body.map((paragraph, index) => <p key={`community-text-${index}`}>{paragraph}</p>)}
           </Col>
           <Col lg={7}>
-              <Statistic className="row g-4 row-cols-1 row-cols-sm-3">
-                  {stats.map(({value, type, icon}, index) => 
-                      <Col key={`community-stat-${index}`}>
-                          <Statistic.Card className="px-5">
-                              <Statistic.Icon icon={icon} />
-                              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-                              <Statistic.Type>{type}</Statistic.Type>
-                          </Statistic.Card>
-                      </Col>
-                  )}
-              </Statistic>
+              <Statistic.Grid columns="3" className="mb-5 gap-4">
+                {stats.map(({value, type, icon}, index) => 
+                  <Statistic.Card key={`community-stat-${index}`} className="px-5">
+                      <Statistic.Icon icon={icon} />
+                      <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                      <Statistic.Type>{type}</Statistic.Type>
+                  </Statistic.Card>
+                )}
+              </Statistic.Grid>
           </Col>
           <EconImpactCommunityImpactCampusStats />
         </Row>

--- a/src/components/blocks/economic-impact/human-impact-stats.js
+++ b/src/components/blocks/economic-impact/human-impact-stats.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
-import { Container, Col } from "react-bootstrap";
+import { Container } from "react-bootstrap";
 import Statistic from 'components/shared/statistic';
 
 const colourOptions = [
@@ -13,16 +13,14 @@ const render = ({ title, stats }) => (
     <>
     <Container>
       <h3 className="visually-hidden">{title}</h3>
-      <Statistic className="row row-cols-1 row-cols-md-3 mb-5 g-4">
+      <Statistic.Grid columns="3" className="mb-5 gap-4">
         {stats.map(({value, type}, index) => 
-          <Col key={`human-impact-stat-${index}`} className="col-lg">
-            <Statistic.BorderCard border={colourOptions[index].border} >
-              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-              <Statistic.Type>{type}</Statistic.Type>
-            </Statistic.BorderCard>
-          </Col>
+          <Statistic.BorderCard key={`human-impact-stat-${index}`} border={colourOptions[index].border} >
+            <Statistic.Value><strong>{value}</strong></Statistic.Value>
+            <Statistic.Type>{type}</Statistic.Type>
+          </Statistic.BorderCard>
         )}
-        </Statistic>
+        </Statistic.Grid>
       </Container>
     </>
 )

--- a/src/components/blocks/economic-impact/intro-stats.js
+++ b/src/components/blocks/economic-impact/intro-stats.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
-import { Container, Col } from "react-bootstrap";
+import { Container } from "react-bootstrap";
 import Statistic from 'components/shared/statistic';
 
 const colourOptions = [
@@ -12,21 +12,19 @@ const colourOptions = [
 ];
 
 const render = ({ title, stats }) => (
-    <>
-    <Container>
-      <h3 className="visually-hidden">{title}</h3>
-      <Statistic className="row row-cols-1 row-cols-lg-3 mb-5 g-4">
-        {stats.map(({value, type}, index) => 
-          <Col key={`intro-stat-${index}`} className="col-lg">
-            <Statistic.BorderCard border={colourOptions[index].border} >
-              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-              <Statistic.Type><span className="text-uppercase">{type}</span></Statistic.Type>
-            </Statistic.BorderCard>
-          </Col>
-        )}
-        </Statistic>
-      </Container>
-    </>
+  <Container>
+    <h3 className="visually-hidden">{title}</h3>
+    <Statistic.Grid columns="3" className="mb-5 gap-4">
+    {stats.map(({value, type}, index) => 
+      <Statistic.BorderCard 
+        key={`intro-stat-${index}`} 
+        border={colourOptions[index].border} >
+        <Statistic.Value><strong>{value}</strong></Statistic.Value>
+        <Statistic.Type><span className="text-uppercase">{type}</span></Statistic.Type>
+      </Statistic.BorderCard>
+    )}
+    </Statistic.Grid>
+  </Container>
 )
 
 const query = graphql`

--- a/src/components/blocks/economic-impact/national-impact-stats.js
+++ b/src/components/blocks/economic-impact/national-impact-stats.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Container, Col } from "react-bootstrap"
+import { Container } from "react-bootstrap"
 import { StaticQuery, graphql } from "gatsby"
 import Statistic from "components/shared/statistic"
 import styled from 'styled-components'
@@ -20,15 +20,14 @@ const render = ({ title, stats }, colourOptions) => (
       <h3 className="visually-hidden">{title}</h3>
         <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
             {stats.map(({value, type}, index) => 
-              <Col key={`nationalimpact-stat-${index}`}>
                 <Statistic.SolidCard 
+                  key={`nationalimpact-stat-${index}`} 
                   background={colourOptions[index].background} 
                   colour={colourOptions[index].colour} 
-                  className="p-5 h-100" >
+                  className="p-5 col">
                   <Statistic.Value><strong>{value}</strong></Statistic.Value>
                   <Statistic.Type>{type}</Statistic.Type>
                 </Statistic.SolidCard>
-              </Col>
             )}
         </Statistic>
     </Container>

--- a/src/components/blocks/economic-impact/pres-message.js
+++ b/src/components/blocks/economic-impact/pres-message.js
@@ -1,12 +1,13 @@
 import React from "react"
-import { Container, Row, Col } from "react-bootstrap"
+import { Col } from "react-bootstrap"
+import PageContainer from 'components/shared/pageContainer';
 import EconImpactAnchors from 'components/blocks/economic-impact/anchors';
 import EconImpactIntro from 'components/blocks/economic-impact/intro';
 import EconImpactIntroStats from 'components/blocks/economic-impact/intro-stats';
 
 const EconImpactPresMessage = () => (
-    <Container className="page-container">
-        <Row className="row-with-vspace site-content">
+    <>
+        <PageContainer.SiteContent>
             <Col md={9} className="pe-4">
                 <EconImpactIntro />
             </Col>
@@ -14,8 +15,9 @@ const EconImpactPresMessage = () => (
                 <EconImpactAnchors />
             </Col>
             <EconImpactIntroStats />
-        </Row>
-    </Container>
+        </PageContainer.SiteContent>
+        
+    </>
 )
 
 export default EconImpactPresMessage

--- a/src/components/blocks/economic-impact/provincial-impact-stats.js
+++ b/src/components/blocks/economic-impact/provincial-impact-stats.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
-import { Col, Container, Row } from "react-bootstrap";
+import { Container, Row } from "react-bootstrap";
 import Statistic from 'components/shared/statistic';
 
 const colourOptions = [
@@ -13,19 +13,17 @@ const render = ({ title, stats }) => (
   <Container>
     <Row className="content-area">
       <h3 className="visually-hidden">{title}</h3>
-      <Statistic className="row row-cols-1 row-cols-md-3 mb-5 g-4">
+      <Statistic.Grid columns="3" className="mb-5 gap-4">
         {stats.map(({value, type, link}, index) => 
-          <Col key={`prov-stat-${index}`} className="col-lg">
-            <Statistic.BorderCard key={`prov-stat-${index}`} border={colourOptions[index].border} >
-              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-              {link ? 
-                <Statistic.Type><a href={link.url} className="fs-3">{type}</a></Statistic.Type>
-                : <Statistic.Type>{type}</Statistic.Type>
-              }
-            </Statistic.BorderCard>
-          </Col>
+          <Statistic.BorderCard key={`prov-stat-${index}`} border={colourOptions[index].border} >
+            <Statistic.Value><strong>{value}</strong></Statistic.Value>
+            {link ? 
+              <Statistic.Type><a href={link.url} className="fs-3">{type}</a></Statistic.Type>
+              : <Statistic.Type>{type}</Statistic.Type>
+            }
+          </Statistic.BorderCard>
         )}
-        </Statistic>
+        </Statistic.Grid>
       </Row>
     </Container>
 )

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -6,13 +6,6 @@ import PageContainer from 'components/shared/pageContainer'
 
 const yaml = require('js-yaml');
 
-const Lead = styled.div`
-  & p {
-    color: #000000;
-    font-size: 2.8rem !important;
-    font-weight: 300;
-  }
-`
 const Button = styled.a`
   width: 100%;
   padding: 2rem;

--- a/src/components/shared/pageContainer.js
+++ b/src/components/shared/pageContainer.js
@@ -15,7 +15,7 @@ PageContainer.SiteContent = ({ children, className}) => (
 )
 
 PageContainer.ContentArea = ({ children, className}) => (
-  <div className={`content-area ${className ?? '' }`}>
+  <div className={`content-area${` ${className}` ?? '' }`}>
     {children}
   </div>
 )

--- a/src/components/shared/pageContainer.js
+++ b/src/components/shared/pageContainer.js
@@ -15,7 +15,7 @@ PageContainer.SiteContent = ({ children, className}) => (
 )
 
 PageContainer.ContentArea = ({ children, className}) => (
-  <div className={`content-area${` ${className}` ?? '' }`}>
+  <div className={`content-area ${className ?? '' }`}>
     {children}
   </div>
 )

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -1,6 +1,16 @@
 import React from "react"
 import styled from "styled-components"
 
+/* Accessible definition lists can only have one nested div.
+In order to achieve gap between bordered stats, use grid instead of row-cols-* */
+const StatisticGrid = styled.dl`
+  display: grid;
+  grid-template-columns: none;
+  @media (min-width: 992px) {
+    grid-template-columns: repeat(${props => (props.columns ?? "3")}, 1fr);
+  }
+`
+
 const StatCard = styled.div`
   background: var(--uog-blue-muted);
   padding: 1.25rem;
@@ -15,6 +25,9 @@ const StatBorderCard = styled(StatCard)`
 const StatSolidCard = styled(StatCard)`
   background: ${props => (props.background ?? "#000000")};
   color: ${props => (props.colour ?? "#ffffff")};
+  && > dd > a {
+    color: ${props => (props.colour ?? "#ffffff")} !important;
+  }
   & > dt {
     color: ${props => (props.colour ?? "#ffffff")};
   }
@@ -28,6 +41,14 @@ const StatValue = styled.dt`
 const StatType = styled.dd`
   font-size: 1.8rem;
   line-height: 1.58;
+  & > a {
+    color: #0068ad !important;
+  }
+
+  & > a:hover,
+  & > a:focus {
+    color: #ffffff !important;
+  }
 `
 const StatIcon = styled.i`
   color: #000;
@@ -37,6 +58,12 @@ const Statistic = ({id, children, className=""}) => (
   <dl id={id} className={`${className}`}>
       {children}
   </dl>
+)
+
+Statistic.Grid = ({id, children, columns, className=""}) => (
+  <StatisticGrid id={id} columns={columns} className={`${className}`}>
+      {children}
+  </StatisticGrid>
 )
 
 Statistic.Card = ({children}) => (


### PR DESCRIPTION
# Summary of changes

After updating International statistics for accessibility, I'm updating Impact Report to fix the same accessibility issues (colour contrast, definition lists). The same stat style is being used on the Lang template, so I fixed it here (on a page that's already live) in preparation to fix it on Lang:

<img width="1329" alt="image" src="https://user-images.githubusercontent.com/1927902/173861801-72d850ef-e2e5-4d96-b791-77c22f282122.png">

## Frontend
- Ensure definition lists only contain a single div (containing dt and dd elements) instead of two nested divs
   - **The issue:** Once I removed all the extra column wrapper divs, the bordered statistics no longer had a gutter between them (a.k.a the extra column wrapper div was necessary to contain the entire bordered card within the boundary of a column).
   - **Solution:** Added a Statistic.Grid component that uses CSS Grid instead of Bootstrap row-cols-* classes. This allows us to use gap-4 which gives us our gutter. I pass in the number of columns as a parameter.
- Update colour contrast for links on statistics

## Backend
None

# Test Plan
- Ensure you have [Accessibility Insights for Web](https://accessibilityinsights.io/docs/web/overview/) installed
- Prepare your build and open the updated Impact Report in Chrome:
    - Either compile the a11ystats branch locally (using api.liveugconthub.uoguelph.dev as the Drupal source) and navigate to /grce/impact-report
    - OR use the following GatsbyCloud build at [https://build-67baa8dd-fdef-48e0-b054-3f3b89520a23.gtsb.io/grce/impact-report/](https://build-67baa8dd-fdef-48e0-b054-3f3b89520a23.gtsb.io/grce/impact-report/)
- Run Impact Report through the Accessibility Insights **Fast Pass** on Chrome.

**Expected Result:** There should no longer be errors resulting from colour contrast issues or definition lists.

Also the [statistics on the International page](https://build-67baa8dd-fdef-48e0-b054-3f3b89520a23.gtsb.io/explore-university-of-guelph-international) should be:
- visually unaffected (a.k.a. they are designed to be NOT full width) by the changes
- the definition elements should still pass the Fast Pass on Chrome