### PR TITLE
Fix modal video on Program pages

### DIFF
--- a/src/components/blocks/economic-impact/community-impact-mealcare.js
+++ b/src/components/blocks/economic-impact/community-impact-mealcare.js
@@ -2,7 +2,7 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import { Container, Row, Col } from "react-bootstrap"
-import Video from "components/shared/video"
+import ModalVideo from "components/shared/modalVideo"
 import Overlay from "components/shared/overlay"
 import styled from "styled-components"
 
@@ -32,12 +32,17 @@ const render = ({ title, body, images, video, testimonial }) => (
                     <Col lg={6} className="fs-3 mb-4">
                         <SectionTitle>{title}</SectionTitle>
                         {body.map((paragraph, index) => <p key={`mealcare-text-${index}`}>{paragraph}</p>)}
-                        <Overlay.ModalButton id={`modal-${video.id}`} className="btn-primary my-4">
-                            <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
-                        </Overlay.ModalButton>
-                        <Overlay.Modal id={`modal-${video.id}`}>
-                            <Video videoID={video.id} videoType={video.type} playerID={`player-${video.id}`} videoTranscript={video.transcript} videoCC={video.captions} />
-                        </Overlay.Modal>
+                        <ModalVideo 
+                            id={video.id} 
+                            src={video.url} 
+                            title={video.title} 
+                            transcript={video.transcript} 
+                            modalButton = {
+                                <button type="button" className="btn btn-primary my-4">
+                                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
+                                </button>
+                            }
+                        />
                     </Col>
                     <Col lg={6} className="d-flex justify-content-center">
                         <GatsbyImage image={getImage(images.foreground.src)} alt={images.foreground.alt} className="align-self-end img-fluid" />

--- a/src/components/blocks/economic-impact/human-impact-banky.js
+++ b/src/components/blocks/economic-impact/human-impact-banky.js
@@ -2,8 +2,8 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import { Container, Col, Row } from "react-bootstrap"
-import Video from "components/shared/video"
 import Overlay from "components/shared/overlay"
+import ModalVideo from "components/shared/modalVideo"
 import styled from "styled-components"
 
 const SectionTitle = styled.h3`
@@ -25,39 +25,44 @@ const QuoteSource = styled.p`
 `
 
 const render = ({ title, body, images, video, testimonial }) => (        
-        <div className="d-flex flex-column bg-dark">
-            <Overlay.GatsbyImage gatsbyImageData={getImage(images.background.src)} alt={images.background.alt}>
-                <Container className="page-container">
-                    <Row className="site-content bg-transparent h-100 text-white pb-0">
-                        <Col lg={6} className="fs-3 mb-4">
-                            <SectionTitle>{title}</SectionTitle>
-                            {body.map((paragraph, index) => <p key={`banky-text-${index}`}>{paragraph}</p>)}
-                            <Overlay.ModalButton id={`modal-${video.id}`} className="btn-primary my-4">
-                                <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
-                            </Overlay.ModalButton>
-                            <Overlay.Modal id={`modal-${video.id}`}>
-                                <Video videoID={video.id} videoType={video.type} playerID={`player-${video.id}`} videoTranscript={video.transcript} videoCC={video.captions} />
-                            </Overlay.Modal>
-                        </Col>
-                        <Col lg={6} className="d-flex justify-content-center">
-                            <GatsbyImage image={getImage(images.foreground.src)} alt={images.foreground.alt} className="align-self-end img-fluid" />
-                        </Col>
-                    </Row>
-                </Container>
-            </Overlay.GatsbyImage>
-
-            <Testimonial className="d-flex justify-content-center">
-                <Row className="w-100 p-5 text-center">
-                    <QuoteText className="display-3 text-white">
-                        <QuoteMark className="fad fa-quote-left pe-2" aria-hidden="true" /> 
-                            <em>{testimonial.quote}</em>
-                        <QuoteMark className="fad fa-quote-right ps-2" aria-hidden="true" />
-                    </QuoteText>
-                    <QuoteSource className="fs-3">~ {testimonial.source.name}</QuoteSource>
+    <div className="d-flex flex-column bg-dark">
+        <Overlay.GatsbyImage gatsbyImageData={getImage(images.background.src)} alt={images.background.alt}>
+            <Container className="page-container">
+                <Row className="site-content bg-transparent h-100 text-white pb-0">
+                    <Col lg={6} className="fs-3 mb-4">
+                        <SectionTitle>{title}</SectionTitle>
+                        {body.map((paragraph, index) => <p key={`banky-text-${index}`}>{paragraph}</p>)}
+                        <ModalVideo 
+                            id={video.id} 
+                            src={video.url} 
+                            title={video.title} 
+                            transcript={video.transcript} 
+                            modalButton = {
+                                <button type="button" className="btn btn-primary my-4">
+                                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
+                                </button>
+                            }
+                        />
+                    </Col>
+                    <Col lg={6} className="d-flex justify-content-center">
+                        <GatsbyImage image={getImage(images.foreground.src)} alt={images.foreground.alt} className="align-self-end img-fluid" />
+                    </Col>
                 </Row>
-            </Testimonial>
-        </div>
-    )
+            </Container>
+        </Overlay.GatsbyImage>
+
+        <Testimonial className="d-flex justify-content-center">
+            <Row className="w-100 p-5 text-center">
+                <QuoteText className="display-3 text-white">
+                    <QuoteMark className="fad fa-quote-left pe-2" aria-hidden="true" /> 
+                        <em>{testimonial.quote}</em>
+                    <QuoteMark className="fad fa-quote-right ps-2" aria-hidden="true" />
+                </QuoteText>
+                <QuoteSource className="fs-3">~ {testimonial.source.name}</QuoteSource>
+            </Row>
+        </Testimonial>
+    </div>
+)
 
 const query = graphql`
   query {

--- a/src/components/blocks/economic-impact/provincial-impact-intro.js
+++ b/src/components/blocks/economic-impact/provincial-impact-intro.js
@@ -2,8 +2,7 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import { Col } from "react-bootstrap"
-import Video from "components/shared/video"
-import Overlay from "components/shared/overlay"
+import ModalVideo from "components/shared/modalVideo"
 import styled from "styled-components"
 
 const Heading = styled.h3`
@@ -29,14 +28,17 @@ const render = ({ title, image, sections }) => (
                 <Section borderColour={colourOptions[index]} className="px-4 mb-5">
                   <div dangerouslySetInnerHTML={{__html: body_html}}></div>
                   { video && 
-                    <>
-                      <Overlay.ModalButton id={`modal-${video.id}`} className="btn-outline-info my-4">
-                          <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
-                      </Overlay.ModalButton>
-                      <Overlay.Modal id={`modal-${video.id}`}>
-                          <Video videoID={video.id} videoType={video.type} playerID={`player-${video.id}`} videoTranscript={video.transcript} videoCC={video.captions} />
-                      </Overlay.Modal>
-                    </>
+                      <ModalVideo 
+                            id={video.id} 
+                            src={video.url} 
+                            title={video.title} 
+                            transcript={video.transcript} 
+                            modalButton = {
+                                <button type="button" className="btn btn-outline-info my-4">
+                                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
+                                </button>
+                            }
+                        />
                   }
                 </Section>
             </div>

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -1,41 +1,45 @@
-import React from "react"
+import React, { useState } from "react"
+import ReactPlayer from 'react-player';
 import PropTypes from "prop-types"
 import { graphql } from "gatsby"
-import Overlay from "./overlay"
-import Video from "./video"
-import { Portal } from "react-portal"
-
+import { Modal, CloseButton } from "react-bootstrap";
 import "../../styles/modalVideo.css"
 
 const ModalVideo = ({ widgetData }) => {
-  const video = widgetData.relationships?.field_media_video
-  const videoId = video?.field_media_oembed_video.split("/").pop()
-  const videoType = video?.field_media_oembed_video.includes("vimeo")
-    ? "vimeo"
-    : "youtube"
-  const modalId = `modal-${widgetData.drupal_id}`
+    
+    const video = widgetData.relationships?.field_media_video;
+    const modalId = `modal-${widgetData.drupal_id}`;
+    const videoSrc = video?.field_media_oembed_video;
+    const videoTitle = video?.name;
+    const videoTranscript = video?.relationships?.field_media_file?.localFile.publicURL;
 
-  return videoId ? (
-    <div className="modal-video" id={`modal-video-${widgetData.drupal_id}`}>
-      <Overlay.ModalButton id={modalId} className="play" btnClass={false}>
-        <i className="fad fa-play-circle" aria-hidden="true"></i>
-        <span className="visually-hidden">Play video: {video.name}</span>
-      </Overlay.ModalButton>
-      <Portal>
-        <Overlay.Modal id={modalId}>
-          <Video
-            videoID={videoId}
-            videoType={videoType}
-            videoTitle={video.name}
-            videoTranscript={
-              video.relationships?.field_media_file?.localFile.publicURL
-            }
-            videoCC={video.relationships?.field_video_cc?.localFile.publicURL}
-          />
-        </Overlay.Modal>
-      </Portal>
-    </div>
-  ) : null
+    const [show, setShow] = useState(false);
+    
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
+
+    return video ? (
+        <div id={modalId} className="modal-video">
+            <button type="button" className="play" onClick={handleShow}>
+                <i className="fad fa-play-circle" aria-hidden="true"></i>
+                <span className="visually-hidden">Play video: {videoTitle}</span>
+            </button>
+            <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
+                <Modal.Header className="bg-dark border-bottom-0">
+                    <Modal.Title className="text-white m-0">{videoTitle}</Modal.Title>
+                    <CloseButton variant="white" aria-label="Hide" />
+                </Modal.Header>
+                <Modal.Body className="bg-dark">
+                    <div className="embed-responsive embed-responsive-16by9">
+                        <ReactPlayer url={videoSrc} width="100%" height="100%" controls="true" playing={show} />
+                    </div>                
+                </Modal.Body>
+                <Modal.Footer className="bg-dark border-top-0">
+                    {videoTranscript && <a className="btn btn-primary w-100" href={videoTranscript}>Download transcript<span className="visually-hidden"> for {videoTitle + " video"}</span></a>}
+                </Modal.Footer>
+            </Modal>
+        </div>
+    ) : null
 }
 
 export default ModalVideo
@@ -50,7 +54,23 @@ export const query = graphql`
     drupal_id
     relationships {
       field_media_video {
-        ...MediaRemoteVideoFragment
+        drupal_id
+        name
+        field_media_oembed_video
+        field_video_height
+        field_video_width
+        relationships {
+          field_media_file {
+            localFile {
+              publicURL
+            }
+          }
+          field_video_cc {
+            localFile {
+              publicURL
+            }
+          }
+        }
       }
     }
   }

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -27,7 +27,7 @@ const ModalVideo = ({ widgetData }) => {
             <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
                 <Modal.Header className="bg-dark border-bottom-0">
                     <Modal.Title className="text-white m-0">{videoTitle}</Modal.Title>
-                    <CloseButton variant="white" aria-label="Hide" />
+                    <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />
                 </Modal.Header>
                 <Modal.Body className="bg-dark">
                     <div className="embed-responsive embed-responsive-16by9">

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -23,7 +23,7 @@ const ModalVideo = ({ widgetData }) => {
                 <i className="fad fa-play-circle" aria-hidden="true"></i>
                 <span className="visually-hidden">Play video: {videoTitle}</span>
             </button>
-            <Modal dialogClassName="modal-dialog-centered fade" show={show} size="lg" onHide={handleClose}>
+            <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
                 <Modal.Header className="bg-dark border-bottom-0">
                     <Modal.Title className="fw-normal text-white m-0">{videoTitle}</Modal.Title>
                     <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
-import ReactPlayer from 'react-player';
+import ReactPlayer from "react-player"
 import PropTypes from "prop-types"
 import { graphql } from "gatsby"
-import { Modal, CloseButton } from "react-bootstrap";
+import { Modal, CloseButton } from "react-bootstrap"
 import "../../styles/modalVideo.css"
 
 const ModalVideo = ({ widgetData }) => {
@@ -13,8 +13,7 @@ const ModalVideo = ({ widgetData }) => {
     const videoTitle = video?.name;
     const videoTranscript = video?.relationships?.field_media_file?.localFile.publicURL;
 
-    const [show, setShow] = useState(false);
-    
+    const [show, setShow] = useState(false);    
     const handleClose = () => setShow(false);
     const handleShow = () => setShow(true);
 
@@ -24,14 +23,14 @@ const ModalVideo = ({ widgetData }) => {
                 <i className="fad fa-play-circle" aria-hidden="true"></i>
                 <span className="visually-hidden">Play video: {videoTitle}</span>
             </button>
-            <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
+            <Modal dialogClassName="modal-dialog-centered fade" show={show} size="lg" onHide={handleClose}>
                 <Modal.Header className="bg-dark border-bottom-0">
-                    <Modal.Title className="text-white m-0">{videoTitle}</Modal.Title>
+                    <Modal.Title className="fw-normal text-white m-0">{videoTitle}</Modal.Title>
                     <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />
                 </Modal.Header>
                 <Modal.Body className="bg-dark">
                     <div className="embed-responsive embed-responsive-16by9">
-                        <ReactPlayer url={videoSrc} width="100%" height="100%" controls="true" playing={show} />
+                        <ReactPlayer url={videoSrc} width="100%" height="100%" controls playing={show} />
                     </div>                
                 </Modal.Body>
                 <Modal.Footer className="bg-dark border-top-0">

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -5,40 +5,43 @@ import { graphql } from "gatsby"
 import { Modal, CloseButton } from "react-bootstrap"
 import "../../styles/modalVideo.css"
 
-const ModalVideo = ({ widgetData }) => {
-    
-    const video = widgetData.relationships?.field_media_video;
-    const modalId = `modal-${widgetData.drupal_id}`;
-    const videoSrc = video?.field_media_oembed_video;
-    const videoTitle = video?.name;
-    const videoTranscript = video?.relationships?.field_media_file?.localFile.publicURL;
+function ModalVideo (props) {
+  const modalId = `modal-${props.id}`;
+  const videoSrc = props.src;
+  const videoTitle = props.title;
+  const videoTranscript = props.transcript;
 
-    const [show, setShow] = useState(false);    
-    const handleClose = () => setShow(false);
-    const handleShow = () => setShow(true);
+  const [show, setShow] = useState(false);    
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
 
-    return video ? (
-        <div id={modalId} className="modal-video">
-            <button type="button" className="play" onClick={handleShow}>
-                <i className="fad fa-play-circle" aria-hidden="true"></i>
-                <span className="visually-hidden">Play video: {videoTitle}</span>
-            </button>
-            <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
-                <Modal.Header className="bg-dark border-bottom-0">
-                    <Modal.Title className="fw-normal text-white m-0">{videoTitle}</Modal.Title>
-                    <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />
-                </Modal.Header>
-                <Modal.Body className="bg-dark">
-                    <div className="embed-responsive embed-responsive-16by9">
-                        <ReactPlayer url={videoSrc} width="100%" height="100%" controls playing={show} />
-                    </div>                
-                </Modal.Body>
-                <Modal.Footer className="bg-dark border-top-0">
-                    {videoTranscript && <a className="btn btn-primary w-100" href={videoTranscript}>Download transcript<span className="visually-hidden"> for {videoTitle + " video"}</span></a>}
-                </Modal.Footer>
-            </Modal>
-        </div>
-    ) : null
+  return videoSrc ? (
+    <div id={modalId} className="modal-video">
+        {props.modalButton ?
+          React.cloneElement(props.modalButton, { onClick: handleShow })
+          : 
+          <button type="button" className="play" onClick={handleShow}>
+            <i className="fad fa-play-circle" aria-hidden="true"></i>
+            <span className="visually-hidden">Play video: {videoTitle}</span>
+          </button>
+        }
+
+        <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
+            <Modal.Header className="bg-dark border-bottom-0">
+                <Modal.Title className="fw-normal text-white m-0">{videoTitle}</Modal.Title>
+                <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />
+            </Modal.Header>
+            <Modal.Body className="bg-dark">
+                <div className="embed-responsive embed-responsive-16by9">
+                    <ReactPlayer url={videoSrc} width="100%" height="100%" controls playing={show} />
+                </div>                
+            </Modal.Body>
+            <Modal.Footer className="bg-dark border-top-0">
+                {videoTranscript && <a className="btn btn-primary w-100" href={videoTranscript}>Download transcript<span className="visually-hidden"> for {videoTitle + " video"}</span></a>}
+            </Modal.Footer>
+        </Modal>
+    </div>
+  ) : null
 }
 
 export default ModalVideo

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -29,7 +29,7 @@ function ModalVideo (props) {
         <Modal dialogClassName="modal-dialog-centered" show={show} size="lg" onHide={handleClose}>
             <Modal.Header className="bg-dark border-bottom-0">
                 <Modal.Title className="fw-normal text-white m-0">{videoTitle}</Modal.Title>
-                <CloseButton variant="white" aria-label="Hide" onClick={handleClose} />
+                <CloseButton variant="white" aria-label="Close video" onClick={handleClose} />
             </Modal.Header>
             <Modal.Body className="bg-dark">
                 <div className="embed-responsive embed-responsive-16by9">

--- a/src/components/shared/overlay.js
+++ b/src/components/shared/overlay.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { GatsbyImage } from "gatsby-plugin-image"
-import classNames from "classnames"
 
 const Overlay = ({ children, className }) => (
   <div className={`bg-black-65 h-100 ${className}`}>{children}</div>
@@ -15,27 +14,6 @@ Overlay.GatsbyImage = ({ children, gatsbyImageData, alt }) => (
     />
     <div style={{ gridArea: "1/1", position: "relative", display: "grid" }}>
       {children}
-    </div>
-  </div>
-)
-
-Overlay.ModalButton = ({ id, children, className, btnClass = true }) => (
-  <button
-    type="button"
-    className={classNames({ btn: btnClass }, className)}
-    data-bs-toggle="modal"
-    data-bs-target={`#${id}`}
-  >
-    {children}
-  </button>
-)
-
-Overlay.Modal = ({ id, children }) => (
-  <div id={id} className="modal fade" tabIndex="-1">
-    <div className="modal-dialog modal-lg modal-dialog-centered">
-      <div className="modal-content">
-        <div className="modal-body p-0 bg-dark">{children}</div>
-      </div>
     </div>
   </div>
 )

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -43,14 +43,20 @@ const WidgetSelector = ({widget}) => {
         case "paragraph__media_text":
           return <MediaText headingClass="mt-md-0" widgetData={widget} />;
         case "paragraph__modal_video_widget":
-          return <ModalVideo widgetData={widget} />
+          const video = widget.relationships?.field_media_video;
+          return video ? <ModalVideo 
+            id={widget.drupal_id}
+            src={video?.field_media_oembed_video}
+            title={video?.name}
+            transcript={video?.relationships?.field_media_file?.localFile.publicURL} /> 
+            : null;
         case "paragraph__section":
             return (<>
-				{widget.field_section_title && <h2>{widget.field_section_title}</h2>}
-				<div key={widget.drupal_id} className="row">
+              {widget.field_section_title && <h2>{widget.field_section_title}</h2>}
+                <div key={widget.drupal_id} className="row">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>
-			</>);
+            </>);
         case "paragraph__section_tabs":
             return <PageTabs pageData={widget} />;
         case "paragraph__stats_widget":


### PR DESCRIPTION
# Summary of changes
Resolves the bug where videos would keep playing even if modal dialog was closed by using react-player and react-bootstrap components

## Frontend
- Refactor `modalVideo.js` to use `react-player` instead of `video.js` 
- Use `Modal` and `CloseButton` components from `react-bootstrap`
- Add event handlers to modal and close button to stop video playback
- Add `onClick` handler to modal button to both open modal and start video playback
- Use `modalVideo.js` component in `overlay.js`

## Backend
N/A

# Test Plan

- Go to https://previewugconthub.uoguelph.dev/programs/bachelor-of-indigenous-environmental-science-and-practice
- Click play button
- Verify modal opens and video playback begins automatically
- Verify playback stops if you hit `Esc`
- Verify playback stops if you click away from the modal
- Verify playback stops if you click the close button
- Repeat above steps on mobile device
- Navigate to, open, and close modal using keyboard only, no mouse
- Repeat above steps for the 3 videos on https://previewugconthub.uoguelph.dev/grce/impact-report/

