### PR TITLE
Allow files and remote video as Yaml Block assets

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -227,6 +227,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_video_width: Int
       field_video_height: Int
       relationships: media__remote_videoRelationships
+      path: AliasPath
     }
     type media__remote_videoRelationships implements Node {
       field_media_file: file__file @link(from: "field_media_file___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -83,6 +83,11 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       drupal_id: String
     }
 
+    union relatedMediaUnion =
+      media__file
+      | media__image
+      | media__remote_video
+
     union media__imagemedia__remote_videoUnion =
       media__image
       | media__remote_video
@@ -186,9 +191,19 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       relationships: block_content__yaml_blockRelationships
     }
     type block_content__yaml_blockRelationships implements Node {
-      field_yaml_files: [media__image] @link(from: "field_yaml_files___NODE")
+      field_yaml_files: [relatedMediaUnion] @link(from: "field_yaml_files___NODE")
     }
     
+    type media__file implements Node {
+      drupal_id: String
+      name: String
+      relationships: media__fileRelationships
+      path: AliasPath
+    }
+    type media__fileRelationships implements Node {
+      field_media_file: file__file @link(from: "field_media_file___NODE")
+    }
+
     type media__image implements Node {
       drupal_id: String
       name: String

--- a/src/components/blocks/international/international-explore-btns.js
+++ b/src/components/blocks/international/international-explore-btns.js
@@ -72,19 +72,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/international/international-explore-lead.js
+++ b/src/components/blocks/international/international-explore-lead.js
@@ -51,19 +51,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/international/international-stats-global.js
+++ b/src/components/blocks/international/international-stats-global.js
@@ -75,19 +75,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/international/international-talk-current-student.js
+++ b/src/components/blocks/international/international-talk-current-student.js
@@ -41,19 +41,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -18,7 +18,9 @@ const render = ({ field_yaml_map, relationships }) => {
     let yamlMap;
     let yamlFiles = {};
     relationships.field_yaml_files.forEach(file => {
-      yamlFiles[file.path.alias] = file;
+      if( file.path?.alias) {
+        yamlFiles[file.path.alias] = file;
+      }
     });
 
     try {

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -63,19 +63,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -18,7 +18,7 @@ const render = ({ field_yaml_map, relationships }) => {
     let yamlMap;
     let yamlFiles = {};
     relationships.field_yaml_files.forEach(file => {
-      yamlFiles[file.path.alias] = file.relationships.field_media_image.localFile;
+      yamlFiles[file.path.alias] = file;
     });
 
     try {
@@ -27,7 +27,7 @@ const render = ({ field_yaml_map, relationships }) => {
       console.log(e);
       return null;
     }
-    
+
     return (
       <PageContainer.SiteContent>
         <PageContainer.ContentArea>
@@ -36,7 +36,7 @@ const render = ({ field_yaml_map, relationships }) => {
               {yamlMap.cards.map(({title, text, image, links}, index) => 
                   <Col key={`international-explore-${index}`}>
                       <div className="card h-100 border-0">
-                          <GatsbyImage image={getImage(yamlFiles[image.src])} alt={image.alt} className="card-img-bottom" />
+                          <GatsbyImage image={getImage(yamlFiles[image.src].relationships.field_media_image.localFile)} alt={image.alt} className="card-img-bottom" />
                           <MediaCardBody className="card-body">
                               <MediaTitle>{title}</MediaTitle>
                               <p>{text}</p>

--- a/src/components/blocks/lang/lang-bcomm-feature-experience.js
+++ b/src/components/blocks/lang/lang-bcomm-feature-experience.js
@@ -76,22 +76,25 @@ const render = ({ field_yaml_map, relationships }) => {
         field_yaml_map
         relationships {
           field_yaml_files {
-            id
-            name
-            relationships {
-              field_media_image {
-                localFile {
-                  childImageSharp {
-                    gatsbyImageData(
-                        placeholder: BLURRED, 
-                        layout: CONSTRAINED
-                    )
+            __typename
+            ... on media__image {
+              id
+              name
+              relationships {
+                field_media_image {
+                  localFile {
+                    childImageSharp {
+                      gatsbyImageData(
+                          placeholder: BLURRED, 
+                          layout: CONSTRAINED
+                      )
+                    }
                   }
                 }
               }
-            }
-            path {
-              alias
+              path {
+                alias
+              }
             }
           }
         }

--- a/src/components/blocks/lang/lang-bcomm-future-cards-advantage.js
+++ b/src/components/blocks/lang/lang-bcomm-future-cards-advantage.js
@@ -62,19 +62,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/lang/lang-bcomm-future-cards.js
+++ b/src/components/blocks/lang/lang-bcomm-future-cards.js
@@ -62,19 +62,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/lang/lang-bcomm-quote.js
+++ b/src/components/blocks/lang/lang-bcomm-quote.js
@@ -62,19 +62,22 @@ const query = graphql`
       field_yaml_map
       relationships {
         field_yaml_files {
-          id
-          name
-          relationships {
-            field_media_image {
-              localFile {
-                childImageSharp {
-                  gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
+                  }
                 }
               }
             }
-          }
-          path {
-            alias
+            path {
+              alias
+            }
           }
         }
       }

--- a/src/components/blocks/lang/lang-bcomm-supportive-community.js
+++ b/src/components/blocks/lang/lang-bcomm-supportive-community.js
@@ -84,22 +84,25 @@ const query = graphql`
         field_yaml_map
         relationships {
           field_yaml_files {
-            id
-            name
-            relationships {
-              field_media_image {
-                localFile {
-                  childImageSharp {
-                    gatsbyImageData(
-                        placeholder: BLURRED, 
-                        layout: CONSTRAINED
-                    )
-                  }
+            __typename
+            ... on media__image {
+                id
+                name
+                relationships {
+                    field_media_image {
+                        localFile {
+                            childImageSharp {
+                                gatsbyImageData(
+                                    placeholder: BLURRED, 
+                                    layout: CONSTRAINED
+                                )
+                            }
+                        }
+                    }
                 }
-              }
-            }
-            path {
-              alias
+                path {
+                    alias
+                }
             }
           }
         }

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -36,7 +36,6 @@ const render = ({ field_yaml_map, relationships }) => {
           <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
           {fileURL && <p><a href={fileURL}>{yamlMap.file.title}</a></p>}
           {imageURL && <GatsbyImage image={getImage(imageURL)} alt={yamlMap.image.alt} />}
-          <p>{video.name}</p>
           {video && <ModalVideo 
             id={video.id} 
             src={video.field_media_oembed_video} 

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -40,7 +40,7 @@ const render = ({ field_yaml_map, relationships }) => {
             id={video.id} 
             src={video.field_media_oembed_video} 
             title={video.name} 
-            transcript={video.relationships.field_media_file?.localFile.publicURL} 
+            transcript={video.relationships?.field_media_file?.localFile.publicURL} 
             modalButton = {
               <button type="button" className="btn btn-primary my-4">
                   <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.name}</span>

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -31,7 +31,7 @@ const render = ({ field_yaml_map, relationships }) => {
       <PageContainer.SiteContent>
         <PageContainer.ContentArea>
           <h2>{yamlMap.title}</h2>
-          <p>yamlMap.body</p>
+          <p>{yamlMap.body}</p>
           {yamlMap.body_paragraphs.map((paragraph, index) => <p key={`example-text-${index}`}>{paragraph}</p>)}
           <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
           {fileURL && <p><a href={fileURL}>{yamlMap.file.title}</a></p>}

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -1,0 +1,127 @@
+import React from "react"
+import { StaticQuery, graphql } from "gatsby"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
+import PageContainer from 'components/shared/pageContainer'
+import ModalVideo from "components/shared/modalVideo"
+
+const yaml = require('js-yaml');
+
+const render = ({ field_yaml_map, relationships }) => {
+    let yamlMap;
+    let yamlFiles = {};
+
+    relationships.field_yaml_files.forEach(file => {
+      if( file.path?.alias) {
+        yamlFiles[file.path.alias] = file;
+      }
+    });
+
+    try {
+      yamlMap = yaml.load(field_yaml_map);
+    } catch (e) {
+      console.log(e);
+      return null;
+    }
+
+    const fileURL = yamlFiles[yamlMap.file.alias]?.relationships.field_media_file.localFile.publicURL;
+    const imageURL = yamlFiles[yamlMap.image.src]?.relationships.field_media_image.localFile;
+    const video = yamlFiles[yamlMap.video.alias];
+
+    return (
+      <PageContainer.SiteContent>
+        <PageContainer.ContentArea>
+          <h2>{yamlMap.title}</h2>
+          <p>yamlMap.body</p>
+          {yamlMap.body_paragraphs.map((paragraph, index) => <p key={`example-text-${index}`}>{paragraph}</p>)}
+          <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
+          {fileURL && <a href={fileURL}>{yamlMap.file.title}</a>}
+          {imageURL && <GatsbyImage image={getImage(imageURL)} alt={yamlMap.image.alt} />}
+          <p>{video.name}</p>
+          {video && <ModalVideo 
+            id={video.id} 
+            src={video.field_media_oembed_video} 
+            title={video.name} 
+            transcript={video.relationships.field_media_file?.localFile.publicURL} 
+            modalButton = {
+              <button type="button" className="btn btn-primary my-4">
+                  <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.name}</span>
+              </button>
+            }
+          />}
+        </PageContainer.ContentArea>
+      </PageContainer.SiteContent>
+)}
+
+
+const query = graphql`
+  query {
+    blockContentYamlBlock(field_yaml_id: {glob: "yaml_block_example"}) {
+      id
+      field_yaml_id
+      field_yaml_map
+      relationships {
+        field_yaml_files {
+          __typename
+          ... on media__image {
+            id
+            name
+            relationships {
+              field_media_image {
+                localFile {
+                  childImageSharp {
+                    gatsbyImageData(placeholder: BLURRED, layout: CONSTRAINED)
+                  }
+                }
+              }
+            }
+            path {
+              alias
+            }
+          }
+          ... on media__file {
+            id
+            drupal_id
+            name
+            relationships {
+              field_media_file {
+                localFile {
+                  publicURL
+                }
+              }
+            }
+            path {
+              alias
+            }
+          }
+          ... on media__remote_video {
+            id
+            drupal_id
+            name
+            field_media_oembed_video
+            field_video_height
+            field_video_width
+            relationships {
+              field_media_file {
+                localFile {
+                  publicURL
+                }
+              }
+              field_video_cc {
+                localFile {
+                  publicURL
+                }
+              }
+            }
+            path {
+              alias
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+export default function YamlBlockExample() {
+  return <StaticQuery query={query} render={({blockContentYamlBlock}) => render(blockContentYamlBlock)} />
+}

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -34,7 +34,7 @@ const render = ({ field_yaml_map, relationships }) => {
           <p>yamlMap.body</p>
           {yamlMap.body_paragraphs.map((paragraph, index) => <p key={`example-text-${index}`}>{paragraph}</p>)}
           <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}} />
-          {fileURL && <a href={fileURL}>{yamlMap.file.title}</a>}
+          {fileURL && <p><a href={fileURL}>{yamlMap.file.title}</a></p>}
           {imageURL && <GatsbyImage image={getImage(imageURL)} alt={yamlMap.image.alt} />}
           <p>{video.name}</p>
           {video && <ModalVideo 

--- a/src/components/blocks/yaml-block-example.js
+++ b/src/components/blocks/yaml-block-example.js
@@ -11,7 +11,7 @@ const render = ({ field_yaml_map, relationships }) => {
     let yamlFiles = {};
 
     relationships.field_yaml_files.forEach(file => {
-      if( file.path?.alias) {
+      if( file.path?.alias ) {
         yamlFiles[file.path.alias] = file;
       }
     });

--- a/src/components/shared/modalVideo.js
+++ b/src/components/shared/modalVideo.js
@@ -1,6 +1,5 @@
 import React, { useState } from "react"
 import ReactPlayer from "react-player"
-import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import { Modal, CloseButton } from "react-bootstrap"
 import "../../styles/modalVideo.css"
@@ -45,10 +44,6 @@ function ModalVideo (props) {
 }
 
 export default ModalVideo
-
-ModalVideo.propTypes = {
-  widgetData: PropTypes.object.isRequired,
-}
 
 export const query = graphql`
   fragment ParagraphModalVideoWidgetFragment on paragraph__modal_video_widget {

--- a/src/components/shared/yamlWidget.js
+++ b/src/components/shared/yamlWidget.js
@@ -27,6 +27,62 @@ const YamlWidget = (props) => {
 export default YamlWidget
 
 export const query = graphql`
+  fragment YamlMediaImageFragment on media__image {
+    id
+    name
+    field_media_image {
+      alt
+    }
+    relationships {
+      field_media_image {
+        localFile {
+          publicURL
+          childImageSharp {
+            gatsbyImageData(width: 1000, placeholder: BLURRED, layout: CONSTRAINED)
+          }
+        }
+      }
+    }
+    path {
+      alias
+    }
+  }
+  fragment YamlMediaFileFragment on media__file {
+    id
+    drupal_id
+    name
+    relationships {
+      field_media_file {
+        localFile {
+          publicURL
+        }
+      }
+    }
+    path {
+      alias
+    }
+  }
+  fragment YamlMediaRemoteVideoFragment on media__remote_video {
+    id
+    drupal_id
+    name
+    field_media_oembed_video
+    field_video_height
+    field_video_width
+    relationships {
+      field_media_file {
+        localFile {
+          publicURL
+        }
+      }
+      field_video_cc {
+        localFile {
+          publicURL
+        }
+      }
+    }
+  }
+  
   fragment YamlWidgetParagraphFragment on paragraph__yaml_widget {
     drupal_id
     relationships {
@@ -35,22 +91,18 @@ export const query = graphql`
         field_yaml_id
         field_yaml_map
         relationships {
-            field_yaml_files{
-                id
-                name
-                relationships {
-                  field_media_image {
-                    localFile {
-                      childImageSharp {
-                        gatsbyImageData(width: 400, placeholder: BLURRED, layout: CONSTRAINED)
-                      }
-                    }
-                  }
-                }
-                path {
-                  alias
-                }
+          field_yaml_files{
+            __typename
+            ... on media__image {
+              ...YamlMediaImageFragment
             }
+            ... on media__file {
+              ...YamlMediaFileFragment
+            }
+            ... on media__remote_video {
+              ...YamlMediaRemoteVideoFragment
+            }
+          }
         }
       }
       field_section_column {

--- a/src/components/shared/yamlWidget.js
+++ b/src/components/shared/yamlWidget.js
@@ -3,18 +3,20 @@ import { graphql } from 'gatsby';
 
 // @todo - add index of components in components/blocks and import all in one line
 // until then, import each component manually below
-import InternationalStatsGlobal from 'components/blocks/international/international-stats-global'
-import InternationalExploreThingsToKnow from 'components/blocks/international/international-things-to-know'
-import InternationalExploreButtons from 'components/blocks/international/international-explore-btns'
-import InternationalExploreGrid from 'components/blocks/international/international-explore-grid'
-import InternationalTalkCurrentStudent from 'components/blocks/international/international-talk-current-student'
-import InternationalExploreLead from 'components/blocks/international/international-explore-lead'
+import YamlBlockExample from 'components/blocks/yaml-block-example';
+import InternationalStatsGlobal from 'components/blocks/international/international-stats-global';
+import InternationalExploreThingsToKnow from 'components/blocks/international/international-things-to-know';
+import InternationalExploreButtons from 'components/blocks/international/international-explore-btns';
+import InternationalExploreGrid from 'components/blocks/international/international-explore-grid';
+import InternationalTalkCurrentStudent from 'components/blocks/international/international-talk-current-student';
+import InternationalExploreLead from 'components/blocks/international/international-explore-lead';
 
 const YamlWidget = (props) => {
     let component = props.blockData.relationships.field_custom_block?.field_yaml_id;
 
     // add new custom components to conditional rendering below
     return ({
+        'yaml_block_example': <YamlBlockExample />,
         'international_stats_global_impact': <InternationalStatsGlobal />,
         'international_explore_things_to_know': <InternationalExploreThingsToKnow />,
         'international_explore_btns': <InternationalExploreButtons />,

--- a/src/components/shared/yamlWidget.js
+++ b/src/components/shared/yamlWidget.js
@@ -81,6 +81,9 @@ export const query = graphql`
         }
       }
     }
+    path {
+      alias
+    }
   }
   
   fragment YamlWidgetParagraphFragment on paragraph__yaml_widget {

--- a/src/data/block/id: yaml_block_example.yml
+++ b/src/data/block/id: yaml_block_example.yml
@@ -1,0 +1,18 @@
+id: yaml_block_example
+title: Example File with Image, Video and File Attached
+body: Ensure  image, video and/or file are attached to the block.
+body_paragraphs:
+  - Line of text in one paragraph.
+  - Another line of text.
+body_html: |
+  <p>Content in the body field that contains <strong>emphasized</strong> elements</p>
+  <p>Another line of text in a different paragraph</p>
+image: 
+  src: /images/placeholder-1200x600.png
+  alt: Example image
+video:
+  title: Name of Video
+  alias: /video/remote/youtube/YIFSRE8SjtM
+file:
+  title: Name of File
+  alias: /media/files/UofG-Fact-Book-2019-2020.pdf

--- a/src/data/block/yaml-block-example.yml
+++ b/src/data/block/yaml-block-example.yml
@@ -11,8 +11,8 @@ image:
   src: /images/placeholder-1200x600.png
   alt: Example image
 video:
-  title: Name of Video
-  alias: /video/remote/youtube/YIFSRE8SjtM
+  title: Gryph Gets a Helping Hand
+  alias: /video/remote/youtube/wcd877TrpOE
 file:
-  title: Name of File
+  title: U of G Fact Book 2019-2020
   alias: /media/files/UofG-Fact-Book-2019-2020.pdf


### PR DESCRIPTION
# Summary of changes
Allow files and remote video as Yaml Block media assets

## Frontend
- Update schema to allow files and remote video (in addition to images) as Yaml Block assets
- Add example YAML block that shows how to handle files, images, and remote videos on Yaml blocks
- Update queries on existing YamlBlocks
- Remove widgetData as a required prop on ModalVideo (removes warning)

## Backend
- Allow File and Remote Video as media assets on Yaml blocks

# Test Plan

Multidev: [https://yamlassets-chug.pantheonsite.io](https://yamlassets-chug.pantheonsite.io)

- If compiling locally, compile branch yamlassets against yamlassets multidev (visit /yaml-test)
- Alternatively, visit [https://build-faa1bb43-b95e-47a2-9f8c-ec48bbb81412.gtsb.io/yaml-test](https://build-faa1bb43-b95e-47a2-9f8c-ec48bbb81412.gtsb.io/yaml-test)
- Bright green inline image should show up
- File should be downloadable (U of G Facebook)
- Watch Video button should play the remote video in a modal window (transcript should be available)

# Change to Yaml Block Syntax
Any yamlblocks that query for images will need to include the typename in the query now. (@snschau - if this gets merged before your branch, you'll need to update the queries on your branch to include the typename.)

This...

```
field_yaml_files {
            id
            name
            relationships {
              field_media_image {
                localFile {
                  childImageSharp {
                    gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
                  }
                }
              }
            }
            path {
              alias
          }
        }
```

will become this...

```
field_yaml_files {
          __typename
          ... on media__image {
            id
            name
            relationships {
              field_media_image {
                localFile {
                  childImageSharp {
                    gatsbyImageData(width: 1400, height: 190, placeholder: BLURRED, layout: CONSTRAINED)
                  }
                }
              }
            }
            path {
              alias
            }
          }
        }
```

# If someone else is merging in future...
1. Merge yamlassets multidev into the dev environment on Pantheon
2. Merge yamlassets branch into master branch