### PR TITLE
Study in canada

### DIFF
--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,7 +42,8 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                   {links.map(({title, url}, index) => 
-                                      {$url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>}
+                                    <>{$index}</>
+                                    //$url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
                                   )}
                               </div>
                           </MediaCardBody>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,7 +42,7 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                   {links.map(({title, url}, index) => 
-                                      {$url !== '' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>}
+                                      {$url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>}
                                   )}
                               </div>
                           </MediaCardBody>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -40,13 +40,11 @@ const render = ({ field_yaml_map, relationships }) => {
                           <MediaCardBody className="card-body">
                               <MediaTitle>{title}</MediaTitle>
                               <p>{text}</p>
-                              if (links.map.url !== '') {
-                                <div className="d-grid d-md-block gap-2">
-                                    {links.map(({title, url}, index) => 
-                                        <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
-                                    )}
-                                </div>
-                              }
+                              <div className="d-grid d-md-block gap-2">
+                                  {links.map(({title, url}, index) => 
+                                      {$url !== '' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>}
+                                  )}
+                              </div>
                           </MediaCardBody>
                       </div>
                   </Col>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -41,9 +41,9 @@ const render = ({ field_yaml_map, relationships }) => {
                               <MediaTitle>{title}</MediaTitle>
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
-                                  {links.map(({title, url}, index) => 
-                                    <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
-                                  )}
+                                {links.map(({title, url}, index) => 
+                                  $url !== 'nolink' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                )}
                               </div>
                           </MediaCardBody>
                       </div>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,7 +42,7 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                 {links.map(({title, url}, index) => 
-                                  $links[{index}].url !== 'nolink' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                  url !== 'nolink' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
                                 )}
                               </div>
                           </MediaCardBody>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,7 +42,7 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                   {links.map(({title, url}, index) => 
-                                    $links.url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                    <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
                                   )}
                               </div>
                           </MediaCardBody>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -32,7 +32,7 @@ const render = ({ field_yaml_map, relationships }) => {
       <PageContainer.SiteContent>
         <PageContainer.ContentArea>
           <h2>{yamlMap.title}</h2>
-          <Row className="row-cols-1 row-cols-md-3 g-4">
+          <Row className="row-cols-1 row-cols-md-2 g-4">
               {yamlMap.cards.map(({title, text, image, links}, index) => 
                   <Col key={`international-explore-${index}`}>
                       <div className="card h-100 border-0">
@@ -40,11 +40,13 @@ const render = ({ field_yaml_map, relationships }) => {
                           <MediaCardBody className="card-body">
                               <MediaTitle>{title}</MediaTitle>
                               <p>{text}</p>
-                              <div className="d-grid d-md-block gap-2">
-                                  {links.map(({title, url}, index) => 
-                                      <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
-                                  )}
-                              </div>
+                              if (links.map.url !== '') {
+                                <div className="d-grid d-md-block gap-2">
+                                    {links.map(({title, url}, index) => 
+                                        <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                    )}
+                                </div>
+                              }
                           </MediaCardBody>
                       </div>
                   </Col>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,7 +42,7 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                 {links.map(({title, url}, index) => 
-                                  $url !== 'nolink' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                  $links[{index}].url !== 'nolink' && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
                                 )}
                               </div>
                           </MediaCardBody>

--- a/src/components/blocks/international/international-things-to-know.js
+++ b/src/components/blocks/international/international-things-to-know.js
@@ -42,8 +42,7 @@ const render = ({ field_yaml_map, relationships }) => {
                               <p>{text}</p>
                               <div className="d-grid d-md-block gap-2">
                                   {links.map(({title, url}, index) => 
-                                    <>{$index}</>
-                                    //$url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
+                                    $links.url !== undefined && <a key={`international-explore-btns-${index}`} href ={url} className="btn btn-info me-md-3 no-icon p-4 text-start">{title}</a>
                                   )}
                               </div>
                           </MediaCardBody>


### PR DESCRIPTION
# Summary of changes
A fourth 'thing to know' has been added to the 'Things You Should Know About the City of Guelph' section of the 'International: Study in Canada' page:
https://www.uoguelph.ca/study-in-canada-improve-life
The change requested is for 2 rows of 2 items max.

## Frontend
Bootstrap class has been modified in `blocks/international/international things-to-know.js`.
Logic has been added to hide buttons if `nolink` is used in Drupal YAML block

## Backend
Drupal YAML block 'international_explore_things_to_know' has been modified to add 4th item. Where no link is available `nolink` is used for link child items (i.e. Title and Url).

# Test Plan
- go to the test page (https://dwletsgo94170.gtsb.io/study-in-canada-improve-life) and verify that 'Things You Should Know About the City of Guelph' section shows the 4 items in a 2 row by 2 column layout compared to a 3x2 layout currently on the live site (https://www.uoguelph.ca/study-in-canada-improve-life)
- check that the 'nolink' button no longer shows on the dev site page (https://dwletsgo94170.gtsb.io/study-in-canada-improve-life)

