### PR TITLE
Add Statistics (New) widget

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -120,8 +120,9 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       | paragraph__links_widget
       | paragraph__media_text
       | paragraph__section
-      | paragraph__stats_widget
       | paragraph__section_tabs
+      | paragraph__stats_widget
+      | paragraph__statistic_widget
       | paragraph__story_widget
       | paragraph__tab_content
       | paragraph__accordion_section
@@ -608,6 +609,24 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_tabs: [paragraph__tab_content] @link(from:"field_tabs___NODE")
       field_section_column: taxonomy_term__section_columns @link(from: "field_section_column___NODE")
     }
+    type paragraph__statistic_item implements Node {
+      drupal_id: String
+      field_stat_value: String
+      field_statistic_represents: BodyField
+      field_font_awesome_icon: String
+      relationships: paragraph__statistic_itemRelationships
+    }
+    type paragraph__statistic_itemRelationships implements Node {
+      field_media_text_media: media__image @link(from: "field_media_text_media___NODE")
+    }
+    type paragraph__statistic_widget implements Node {
+      drupal_id: String
+      relationships: paragraph__statistic_widgetRelationships
+    }
+    type paragraph__statistic_widgetRelationships implements Node {
+      field_statistic: [paragraph__statistic_item] @link(from: "field_statistic___NODE")
+      field_statistic_style: taxonomy_term__statistic_styles @link(from: "field_statistic_style___NODE")
+    }
     type paragraph__stats_widget implements Node {
       drupal_id: String
       relationships: paragraph__stats_widgetRelationships
@@ -752,6 +771,11 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_units: [taxonomy_term__units]
     }
     type taxonomy_term__statistic_type implements Node & TaxonomyInterface {
+      drupal_id: String
+      drupal_internal__tid: Int
+      name: String
+    }
+    type taxonomy_term__statistic_styles implements Node & TaxonomyInterface {
       drupal_id: String
       drupal_internal__tid: Int
       name: String

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -139,6 +139,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       | paragraph__links_widget
       | paragraph__media_text
       | paragraph__section_tabs
+      | paragraph__statistic_widget
       | paragraph__stats_widget
       | paragraph__section_buttons
       | paragraph__button_widget

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -106,6 +106,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     
     union storyWidgetParagraphUnion =
       paragraph__story_image_cutout_background
+      | paragraph__statistic_widget
 
     union storyCutoutParagraphUnion =
       paragraph__story_quote

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -9,6 +9,7 @@ import LinksItems from 'components/shared/linksItems';
 import MediaText from 'components/shared/mediaText';
 import PageTabs from 'components/shared/pageTabs';
 import SectionButtons from 'components/shared/sectionButtons';
+import StatisticWidget from 'components/shared/statisticWidget';
 import StatsWidget from 'components/shared/statsWidget';
 import YamlWidget from 'components/shared/yamlWidget';
 import { ConditionalWrapper } from 'utils/ug-utils';
@@ -41,6 +42,8 @@ function renderPrimary(widget) {
             return <MediaText key={widget.drupal_id} widgetData={widget} region="Primary" />;
         case "paragraph__section_tabs":
             return <PageTabs pageData={widget} />;
+        case "paragraph__statistic_widget":
+            return <StatisticWidget statisticData={widget} />;
         case "paragraph__stats_widget":
             return <StatsWidget key={widget.drupal_id} statsWidgetData={widget} />;
         case "paragraph__section_buttons":
@@ -154,6 +157,9 @@ export const query = graphql`
         ... on paragraph__media_text {
             ...MediaTextParagraphFragment
         }
+        ... on paragraph__statistic_widget {
+            ...StatisticWidgetParagraphFragment
+          } 
         ... on paragraph__stats_widget {
             ...StatsWidgetParagraphFragment
         }

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -9,15 +9,14 @@ const StatisticGrid = styled.dl`
   @media (min-width: 992px) {
     grid-template-columns: repeat(${props => (props.columns ?? "3")}, 1fr);
   }
-`
-
+`;
 const StatCard = styled.div`
   background: var(--uog-blue-muted);
   padding: 1.25rem;
   min-width: 25%;
   word-wrap: break-word;
   text-align: center;
-`
+`;
 const StatBorderCard = styled(StatCard)`
   border-left: 1rem solid ${props => (props.border ?? "#000000")};
   text-align: left;
@@ -25,7 +24,7 @@ const StatBorderCard = styled(StatCard)`
 const StatSolidCard = styled(StatCard)`
   background: ${props => (props.background ?? "#000000")};
   color: ${props => (props.colour ?? "#ffffff")};
-  && > dd > a {
+  && > dd a {
     color: ${props => (props.colour ?? "#ffffff")} !important;
   }
   & > dt {
@@ -49,10 +48,10 @@ const StatType = styled.dd`
   & > a:focus {
     color: #ffffff !important;
   }
-`
+`;
 const StatIcon = styled.i`
   color: #000;
-`
+`;
 
 const Statistic = ({id, children, className=""}) => (
   <dl id={id} className={`${className}`}>

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -11,7 +11,7 @@ const StatisticGrid = styled.dl`
   }
 `;
 const StatCard = styled.div`
-  background: var(--uog-blue-muted);
+  background: #f5f7fa;
   padding: 1.25rem;
   min-width: 25%;
   word-wrap: break-word;

--- a/src/components/shared/statistic.js
+++ b/src/components/shared/statistic.js
@@ -50,7 +50,7 @@ const StatType = styled.dd`
   }
 `;
 const StatIcon = styled.i`
-  color: #000;
+  color: ${props => (props.colour ?? "#000")};
 `;
 
 const Statistic = ({id, children, className=""}) => (
@@ -83,8 +83,8 @@ Statistic.SolidCard = ({background, colour, children, className=""}) => (
     </StatSolidCard>
 )
 
-Statistic.Icon = ({icon}) => (
-  <StatIcon className={`${icon} mt-3 fa-4x`} aria-hidden="true" />
+Statistic.Icon = ({icon, colour}) => (
+  <StatIcon colour={colour} className={`${icon} mt-3 fa-4x`} aria-hidden="true" />
 )
 
 Statistic.Value = ({children, fontsize, className=""}) => (

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -5,9 +5,11 @@ import { Container } from "react-bootstrap"
 import Statistic from 'components/shared/statistic'
 import styled from "styled-components"
 
+
 const Gradient = styled.div`
-  background: linear-gradient(to right,#000 0%,#000 60%,#69A3B9 60%,#69A3B9 100%);
+  background: ${props => (props.gradientStyle ?? "none")};
 `
+
 const gradientColourOptions = [
   {background: "var(--black)", colour: "#FFFFFF"},
   {background: "var(--uog-red)", colour: "#FFFFFF"},
@@ -15,13 +17,51 @@ const gradientColourOptions = [
   {background: "var(--uog-blue)", colour: "#000000"},
 ];
 
-const borderColourOptions = [
-  {border: "var(--black)"},
-  {border: "var(--uog-red)"},
-  {border: "var(--uog-yellow)"},
-  {border: "var(--uog-blue)"},
-  {border: "var(--black)"},
-]
+const GradientStatistic = ({stats}) => {
+  let numStats = stats.length;
+
+  // default is displaying 3 colours in a row
+  let rowClasses = "row-cols-sm-3";
+  let gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#ffc72a 60%,#ffc72a 100%)";
+
+  
+  if (numStats === 1){
+    // one colour
+    rowClasses = "row-cols-sm-1";
+    gradientStyle = "#000000";
+  } else if (numStats % 4 === 0) {
+    // four colour
+    rowClasses = "row-cols-sm-2 row-cols-lg-4";
+    gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#69A3B9 60%,#69A3B9 100%)";
+  } else if (numStats % 2 === 0) {
+    // two colours
+    rowClasses = "row-cols-sm-2";
+    gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#c20430 60%,#c20430 100%)";
+  }
+
+  return <Gradient className="d-flex flex-column" gradientStyle={gradientStyle}>
+    <Container className="page-container p-0">
+        <Statistic className={`row g-0 row-cols-1 ${rowClasses} justify-content-center mb-0`}>
+            {stats.map((stat, index) => {
+              let type = stat.field_statistic_represents;
+              let value = stat.field_stat_value;
+              let icon = stat.field_font_awesome_icon;
+
+              return <Statistic.SolidCard 
+                    key={`gradient-stat-${stat.drupal_id}`} 
+                    background={gradientColourOptions[index%gradientColourOptions.length].background} 
+                    colour={gradientColourOptions[index%gradientColourOptions.length].colour} 
+                    className="p-5 col">
+                      {icon && <Statistic.Icon icon={icon} />}
+                      <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                      <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+                  </Statistic.SolidCard>
+              }
+            )}
+        </Statistic>
+    </Container>
+  </Gradient>
+}
 
 const solidColourOptions = [
   {background: "var(--black)", colour: "#FFFFFF"},
@@ -29,9 +69,9 @@ const solidColourOptions = [
   {background: "var(--uog-yellow)", colour: "#000000"},
 ];
 
-const SolidColourStatistic = ({stats}) => {
+const SolidColourStatistic = ({stats, numColumns}) => {
   return <Container>
-    <Statistic.Grid columns="3" className="mb-5 gap-4">
+    <Statistic.Grid columns={numColumns} className="mb-5 gap-4">
           {stats.map((stat, index) => {
               let type = stat.field_statistic_represents;
               let value = stat.field_stat_value;
@@ -43,13 +83,13 @@ const SolidColourStatistic = ({stats}) => {
 
               return <Statistic.SolidCard  
                 key={`solid-stat-${stat.drupal_id}`} 
-                background={solidColourOptions[index].background} 
-                colour={solidColourOptions[index].colour}
+                background={solidColourOptions[index%solidColourOptions.length].background} 
+                colour={solidColourOptions[index%solidColourOptions.length].colour}
                 className="pt-4 pb-0 px-0 h-100 card border-0" >
                   {icon && <Statistic.Icon icon={icon} />}
                   <Statistic.Value><strong>{value}</strong></Statistic.Value>
                   <Statistic.Type className="mb-4 px-5"><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-                  <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd>
+                  {image.src && <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd>}
               </Statistic.SolidCard>
             }
           )}
@@ -57,9 +97,9 @@ const SolidColourStatistic = ({stats}) => {
   </Container>
 } 
 
-const NoBorderStatistic = ({stats}) => {
+const NoBorderStatistic = ({stats, numColumns}) => {
   return <Container>
-    <Statistic.Grid columns="3" className="my-5 gap-4">
+    <Statistic.Grid columns={numColumns} className="my-5 gap-4">
       {stats.map((stat) => {
         let type = stat.field_statistic_represents;
         let value = stat.field_stat_value;
@@ -76,9 +116,17 @@ const NoBorderStatistic = ({stats}) => {
   </Container>
 } 
 
-const LeftBorderStatistic = ({stats}) => {
+const borderColourOptions = [
+  {border: "var(--black)"},
+  {border: "var(--uog-red)"},
+  {border: "var(--uog-yellow)"},
+  {border: "var(--uog-blue)"},
+  {border: "var(--black)"},
+]
+
+const LeftBorderStatistic = ({stats, numColumns}) => {
   return <Container>
-    <Statistic.Grid columns="3" className="my-5 gap-4">
+    <Statistic.Grid columns={numColumns} className="my-5 gap-4">
       {stats.map((stat, index) => {
         let type = stat.field_statistic_represents;
         let value = stat.field_stat_value;
@@ -86,7 +134,7 @@ const LeftBorderStatistic = ({stats}) => {
 
         return <Statistic.BorderCard 
             key={`border-stat-${stat.drupal_id}`} 
-            border={borderColourOptions[index].border} >
+            border={borderColourOptions[index%borderColourOptions.length].border} >
               {icon && <Statistic.Icon icon={icon} />}
               <Statistic.Value><strong>{value}</strong></Statistic.Value>
               <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
@@ -97,41 +145,25 @@ const LeftBorderStatistic = ({stats}) => {
   </Container>
 }
 
-const GradientStatistic = ({stats}) => {
-  return <Gradient className="d-flex flex-column">
-    <Container className="page-container p-0">
-        <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
-            {stats.map((stat, index) => {
-              let type = stat.field_statistic_represents;
-              let value = stat.field_stat_value;
-              let icon = stat.field_font_awesome_icon;
-
-              return <Statistic.SolidCard 
-                    key={`gradient-stat-${stat.drupal_id}`} 
-                    background={gradientColourOptions[index].background} 
-                    colour={gradientColourOptions[index].colour} 
-                    className="p-5 col">
-                      {icon && <Statistic.Icon icon={icon} />}
-                      <Statistic.Value><strong>{value}</strong></Statistic.Value>
-                      <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-                  </Statistic.SolidCard>
-              }
-            )}
-        </Statistic>
-    </Container>
-  </Gradient>
-}
-
 const StatisticSelector = ({statistics, style}) => {
+  let numStats = statistics.length;
+  let numColumns = 3;
+
+  if (numStats % 5 === 0){
+    numColumns = 3;
+  } else if(numStats % 2 === 0){
+    numColumns = 2;
+  }
+
   switch (style) {
       case "Light Blue":
-          return <NoBorderStatistic stats={statistics} />
+          return <NoBorderStatistic stats={statistics} numColumns={numColumns} />
       case "Left Border":
-          return <LeftBorderStatistic stats={statistics} />
+          return <LeftBorderStatistic stats={statistics} numColumns={numColumns} />
       case "Gradient of Solid Colours":
           return <GradientStatistic stats={statistics} />
       case "Solid Colours":
-          return <SolidColourStatistic stats={statistics} />
+          return <SolidColourStatistic stats={statistics} numColumns={numColumns} />
       default:
           return null;
   }

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { graphql } from 'gatsby';
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { Container } from "react-bootstrap"
+import PageContainer from 'components/shared/pageContainer';
 import Statistic from 'components/shared/statistic'
 import styled from "styled-components"
 
@@ -15,53 +16,57 @@ const gradientColourOptions = [
   {background: "var(--uog-red)", colour: "#FFFFFF"},
   {background: "var(--uog-yellow)", colour: "#000000"},
   {background: "var(--uog-blue)", colour: "#000000"},
+  {background: "var(--uog-yellow)", colour: "#000000"},
+  {background: "var(--black)", colour: "#FFFFFF"},
+  {background: "var(--uog-blue)", colour: "#000000"},
+  {background: "var(--uog-red)", colour: "#FFFFFF"},
 ];
 
 const GradientStatistic = ({stats}) => {
   let numStats = stats.length;
 
   // default is displaying 3 colours in a row
-  let rowClasses = "row-cols-sm-3";
+  let rowClasses = "row-cols-md-3";
   let gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#ffc72a 60%,#ffc72a 100%)";
 
-  
   if (numStats === 1){
     // one colour
     rowClasses = "row-cols-sm-1";
     gradientStyle = "#000000";
+  } else if (numStats === 2) {
+    // two colours
+    rowClasses = "row-cols-sm-2";
+    gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#c20430 60%,#c20430 100%)";
   } else if (numStats % 4 === 0) {
     // four colour
     rowClasses = "row-cols-sm-2 row-cols-lg-4";
     gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#69A3B9 60%,#69A3B9 100%)";
-  } else if (numStats % 2 === 0) {
-    // two colours
-    rowClasses = "row-cols-sm-2";
-    gradientStyle = "linear-gradient(to right,#000 0%,#000 60%,#c20430 60%,#c20430 100%)";
   }
 
-  return <Gradient className="d-flex flex-column" gradientStyle={gradientStyle}>
-    <Container className="page-container p-0">
-        <Statistic className={`row g-0 row-cols-1 ${rowClasses} justify-content-center mb-0`}>
-            {stats.map((stat, index) => {
-              let type = stat.field_statistic_represents;
-              let value = stat.field_stat_value;
-              let icon = stat.field_font_awesome_icon;
+  return (
+    <Gradient className="d-flex flex-column mb-4" gradientStyle={gradientStyle}>
+      <Container className="page-container p-0">
+          <Statistic className={`row g-0 row-cols-1 ${rowClasses} justify-content-center mb-0`}>
+              {stats.map((stat, index) => {
+                let type = stat.field_statistic_represents;
+                let value = stat.field_stat_value;
+                let icon = stat.field_font_awesome_icon;
 
-              return <Statistic.SolidCard 
-                    key={`gradient-stat-${stat.drupal_id}`} 
-                    background={gradientColourOptions[index%gradientColourOptions.length].background} 
-                    colour={gradientColourOptions[index%gradientColourOptions.length].colour} 
-                    className="p-5 col">
-                      {icon && <Statistic.Icon icon={icon} />}
-                      <Statistic.Value><strong>{value}</strong></Statistic.Value>
-                      <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-                  </Statistic.SolidCard>
-              }
-            )}
-        </Statistic>
-    </Container>
-  </Gradient>
-}
+                return <Statistic.SolidCard 
+                      key={`gradient-stat-${stat.drupal_id}`} 
+                      background={gradientColourOptions[index%gradientColourOptions.length].background} 
+                      colour={gradientColourOptions[index%gradientColourOptions.length].colour} 
+                      className="p-5 col">
+                        {icon && <Statistic.Icon icon={icon} colour={gradientColourOptions[index%gradientColourOptions.length].colour} />}
+                        <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                        <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+                    </Statistic.SolidCard>
+                }
+              )}
+          </Statistic>
+      </Container>
+    </Gradient>
+)}
 
 const solidColourOptions = [
   {background: "var(--black)", colour: "#FFFFFF"},
@@ -70,8 +75,10 @@ const solidColourOptions = [
 ];
 
 const SolidColourStatistic = ({stats, numColumns}) => {
-  return <Container>
-    <Statistic.Grid columns={numColumns} className="mb-5 gap-4">
+  return (
+    <PageContainer.SiteContent>
+      <Container>
+        <Statistic.Grid columns={numColumns} className="gap-4">
           {stats.map((stat, index) => {
               let type = stat.field_statistic_represents;
               let value = stat.field_stat_value;
@@ -86,7 +93,7 @@ const SolidColourStatistic = ({stats, numColumns}) => {
                 background={solidColourOptions[index%solidColourOptions.length].background} 
                 colour={solidColourOptions[index%solidColourOptions.length].colour}
                 className="pt-4 pb-0 px-0 h-100 card border-0" >
-                  {icon && <Statistic.Icon icon={icon} />}
+                  {icon && <Statistic.Icon icon={icon} colour={solidColourOptions[index%solidColourOptions.length].colour} />}
                   <Statistic.Value><strong>{value}</strong></Statistic.Value>
                   <Statistic.Type className="mb-4 px-5"><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
                   {image.src && <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd>}
@@ -94,26 +101,31 @@ const SolidColourStatistic = ({stats, numColumns}) => {
             }
           )}
       </Statistic.Grid>
-  </Container>
-} 
+    </Container>
+  </PageContainer.SiteContent>
+)} 
 
 const NoBorderStatistic = ({stats, numColumns}) => {
-  return <Container>
-    <Statistic.Grid columns={numColumns} className="my-5 gap-4">
-      {stats.map((stat) => {
-        let type = stat.field_statistic_represents;
-        let value = stat.field_stat_value;
-        let icon = stat.field_font_awesome_icon;
+  return (
+    <PageContainer.SiteContent>
+      <Container>
+        <Statistic.Grid columns={numColumns} className="gap-4">
+          {stats.map((stat) => {
+            let type = stat.field_statistic_represents;
+            let value = stat.field_stat_value;
+            let icon = stat.field_font_awesome_icon;
 
-        return <Statistic.Card key={`noborder-stat-${stat.drupal_id}`} className="px-5">
-              {icon && <Statistic.Icon icon={icon} />}
-              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-              <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-          </Statistic.Card>
-        }
-      )}
-    </Statistic.Grid>
-  </Container>
+            return <Statistic.Card key={`noborder-stat-${stat.drupal_id}`} className="px-5">
+                  {icon && <Statistic.Icon icon={icon} />}
+                  <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                  <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+              </Statistic.Card>
+            }
+          )}
+        </Statistic.Grid>
+      </Container>
+    </PageContainer.SiteContent>
+  )
 } 
 
 const borderColourOptions = [
@@ -125,35 +137,32 @@ const borderColourOptions = [
 ]
 
 const LeftBorderStatistic = ({stats, numColumns}) => {
-  return <Container>
-    <Statistic.Grid columns={numColumns} className="my-5 gap-4">
-      {stats.map((stat, index) => {
-        let type = stat.field_statistic_represents;
-        let value = stat.field_stat_value;
-        let icon = stat.field_font_awesome_icon;
+  return (
+    <PageContainer.SiteContent>
+      <Container>
+        <Statistic.Grid columns={numColumns} className="gap-4">
+          {stats.map((stat, index) => {
+            let type = stat.field_statistic_represents;
+            let value = stat.field_stat_value;
+            let icon = stat.field_font_awesome_icon;
 
-        return <Statistic.BorderCard 
-            key={`border-stat-${stat.drupal_id}`} 
-            border={borderColourOptions[index%borderColourOptions.length].border} >
-              {icon && <Statistic.Icon icon={icon} />}
-              <Statistic.Value><strong>{value}</strong></Statistic.Value>
-              <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-          </Statistic.BorderCard>
-        }
-      )}
-    </Statistic.Grid>
-  </Container>
-}
+            return <Statistic.BorderCard 
+                key={`border-stat-${stat.drupal_id}`} 
+                border={borderColourOptions[index%borderColourOptions.length].border} >
+                  {icon && <Statistic.Icon icon={icon} />}
+                  <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                  <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+              </Statistic.BorderCard>
+            }
+          )}
+        </Statistic.Grid>
+      </Container>
+    </PageContainer.SiteContent>
+)}
 
 const StatisticSelector = ({statistics, style}) => {
   let numStats = statistics.length;
-  let numColumns = 3;
-
-  if (numStats % 5 === 0){
-    numColumns = 3;
-  } else if(numStats % 2 === 0){
-    numColumns = 2;
-  }
+  let numColumns =  ((numStats === 2) || (numStats === 4)) ? 2 : 3;
 
   switch (style) {
       case "Light Blue":

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import { Container } from "react-bootstrap"
+import Statistic from 'components/shared/statistic'
+import styled from "styled-components"
+
+const Gradient = styled.div`
+  background: linear-gradient(to right,#000 0%,#000 60%,#69A3B9 60%,#69A3B9 100%);
+`
+const gradientColourOptions = [
+  {background: "var(--black)", colour: "#FFFFFF"},
+  {background: "var(--uog-red)", colour: "#FFFFFF"},
+  {background: "var(--uog-yellow)", colour: "#000000"},
+  {background: "var(--uog-blue)", colour: "#000000"},
+];
+
+const GradientStatistic = ({stats, id}) => {
+  return <Gradient className="d-flex flex-column">
+    <Container className="page-container p-0">
+        <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
+            {stats.map((stat, index) => {
+              let type = stat.field_statistic_represents;
+              let value = stat.field_stat_value;
+              let icon = stat.field_font_awesome_icon;
+
+              return <Statistic.SolidCard 
+                    key={`gradient-stat-${stat.drupal_id}`} 
+                    background={gradientColourOptions[index].background} 
+                    colour={gradientColourOptions[index].colour} 
+                    className="p-5 col">
+                    <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                    <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+                  </Statistic.SolidCard>
+              }
+            )}
+        </Statistic>
+    </Container>
+  </Gradient>
+}
+
+const StatisticSelector = ({statistics, style}) => {
+  console.log(statistics)
+  switch (style) {
+      case "Light Blue":
+          return <h1>Light Blue</h1>;
+      case "Left Border":
+          return <h1>Left Border</h1>;
+      case "Gradient of Solid Colours":
+          return <GradientStatistic stats={statistics} />
+      case "Solid Colours":
+          return <h1>Solid Colours</h1>;
+      default:
+          return null;
+  }
+}
+
+const StatisticWidget = (props) => {
+  let statItems = props.statisticData?.relationships?.field_statistic;
+  let statStyle = props.statisticData?.relationships?.field_statistic_style.name;
+
+  return statItems ? 
+    <StatisticSelector statistics={statItems} style={statStyle} /> 
+    : null
+}
+
+export default StatisticWidget
+
+export const query = graphql`
+fragment StatisticWidgetParagraphFragment on paragraph__statistic_widget {
+  drupal_id
+  relationships {
+    field_statistic {
+      __typename
+      ... on paragraph__statistic_item {
+        drupal_id
+        field_stat_value
+        field_statistic_represents {
+          processed
+        }
+        field_font_awesome_icon
+        relationships {
+          field_media_text_media {
+            ... on media__image {
+              name
+              field_media_image {
+                alt
+              }
+              relationships {
+                field_media_image {
+                  publicUrl
+                  gatsbyImage(
+                    layout: CONSTRAINED,
+                    placeholder: BLURRED,
+                    width: 600,
+                  )
+                }
+              }
+            }
+
+          } 
+        }
+      }
+    }
+    field_statistic_style {
+      name
+    }
+  }
+}
+`

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -14,7 +14,86 @@ const gradientColourOptions = [
   {background: "var(--uog-blue)", colour: "#000000"},
 ];
 
-const GradientStatistic = ({stats, id}) => {
+const borderColourOptions = [
+  {border: "var(--black)"},
+  {border: "var(--uog-red)"},
+  {border: "var(--uog-yellow)"},
+  {border: "var(--uog-blue)"},
+  {border: "var(--black)"},
+]
+
+const solidColourOptions = [
+  {background: "var(--black)", colour: "#FFFFFF"},
+  {background: "var(--uog-red)", colour: "#FFFFFF"},
+  {background: "var(--uog-yellow)", colour: "#000000"},
+];
+
+const SolidColourStatistic = ({stats}) => {
+  return <Container>
+    <Statistic.Grid columns="3" className="mb-5 gap-4">
+          {stats.map((stat, index) => {
+              let type = stat.field_statistic_represents;
+              let value = stat.field_stat_value;
+              let icon = stat.field_font_awesome_icon;
+
+              return <Statistic.SolidCard  
+                key={`solid-stat-${stat.drupal_id}`} 
+                background={solidColourOptions[index].background} 
+                colour={solidColourOptions[index].colour}
+                className="pt-4 pb-0 px-0 h-100 card border-0" >
+                  {icon && <Statistic.Icon icon={icon} />}
+                  <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                  <Statistic.Type className="mb-4 px-5"><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+                  {/* @todo: ADD IMAGE */}
+                  {/* <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd> */}
+              </Statistic.SolidCard>
+            }
+          )}
+      </Statistic.Grid>
+  </Container>
+} 
+
+const NoBorderStatistic = ({stats}) => {
+  return <Container>
+    <Statistic.Grid columns="3" className="my-5 gap-4">
+      {stats.map((stat) => {
+        let type = stat.field_statistic_represents;
+        let value = stat.field_stat_value;
+        let icon = stat.field_font_awesome_icon;
+
+        return <Statistic.Card key={`noborder-stat-${stat.drupal_id}`} className="px-5">
+              {icon && <Statistic.Icon icon={icon} />}
+              <Statistic.Value><strong>{value}</strong></Statistic.Value>
+              <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+          </Statistic.Card>
+        }
+      )}
+    </Statistic.Grid>
+  </Container>
+} 
+
+const LeftBorderStatistic = ({stats}) => {
+  return <Container>
+    <Statistic.Grid columns="3" className="my-5 gap-4">
+      {stats.map((stat, index) => {
+        let type = stat.field_statistic_represents;
+        let value = stat.field_stat_value;
+        let icon = stat.field_font_awesome_icon;
+
+        return <Statistic.BorderCard 
+            key={`border-stat-${stat.drupal_id}`} 
+            border={borderColourOptions[index].border} >
+              {icon && <Statistic.Icon icon={icon} />}
+              <Statistic.Value><strong>{value}</strong></Statistic.Value>
+              <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+          </Statistic.BorderCard>
+        }
+      )}
+    </Statistic.Grid>
+  </Container>
+}
+
+const GradientStatistic = ({stats}) => {
   return <Gradient className="d-flex flex-column">
     <Container className="page-container p-0">
         <Statistic className="row g-0 row-cols-1 row-cols-sm-2 row-cols-lg-4 justify-content-center mb-0">
@@ -28,8 +107,9 @@ const GradientStatistic = ({stats, id}) => {
                     background={gradientColourOptions[index].background} 
                     colour={gradientColourOptions[index].colour} 
                     className="p-5 col">
-                    <Statistic.Value><strong>{value}</strong></Statistic.Value>
-                    <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
+                      {icon && <Statistic.Icon icon={icon} />}
+                      <Statistic.Value><strong>{value}</strong></Statistic.Value>
+                      <Statistic.Type><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
                   </Statistic.SolidCard>
               }
             )}
@@ -39,16 +119,15 @@ const GradientStatistic = ({stats, id}) => {
 }
 
 const StatisticSelector = ({statistics, style}) => {
-  console.log(statistics)
   switch (style) {
       case "Light Blue":
-          return <h1>Light Blue</h1>;
+          return <NoBorderStatistic stats={statistics} />
       case "Left Border":
-          return <h1>Left Border</h1>;
+          return <LeftBorderStatistic stats={statistics} />
       case "Gradient of Solid Colours":
           return <GradientStatistic stats={statistics} />
       case "Solid Colours":
-          return <h1>Solid Colours</h1>;
+          return <SolidColourStatistic stats={statistics} />
       default:
           return null;
   }

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import { Container } from "react-bootstrap"
 import Statistic from 'components/shared/statistic'
 import styled from "styled-components"
@@ -35,6 +36,10 @@ const SolidColourStatistic = ({stats}) => {
               let type = stat.field_statistic_represents;
               let value = stat.field_stat_value;
               let icon = stat.field_font_awesome_icon;
+              let image = {
+                src: stat.relationships?.field_media_text_media?.relationships?.field_media_image,
+                alt: stat.relationships?.field_media_text_media?.field_media_image?.alt,
+              }
 
               return <Statistic.SolidCard  
                 key={`solid-stat-${stat.drupal_id}`} 
@@ -44,8 +49,7 @@ const SolidColourStatistic = ({stats}) => {
                   {icon && <Statistic.Icon icon={icon} />}
                   <Statistic.Value><strong>{value}</strong></Statistic.Value>
                   <Statistic.Type className="mb-4 px-5"><span dangerouslySetInnerHTML={{__html: type.processed}} /></Statistic.Type>
-                  {/* @todo: ADD IMAGE */}
-                  {/* <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd> */}
+                  <dd className="mb-0 h-100"><GatsbyImage image={getImage(image.src)} alt={image.alt} className="h-100 card-img-bottom" /></dd>
               </Statistic.SolidCard>
             }
           )}

--- a/src/components/shared/statisticWidget.js
+++ b/src/components/shared/statisticWidget.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import { GatsbyImage, getImage } from "gatsby-plugin-image";
-import { Container } from "react-bootstrap"
+import { Container } from "react-bootstrap";
 import PageContainer from 'components/shared/pageContainer';
-import Statistic from 'components/shared/statistic'
-import styled from "styled-components"
+import Statistic from 'components/shared/statistic';
+import styled from "styled-components";
 
 
 const Gradient = styled.div`

--- a/src/components/shared/story.js
+++ b/src/components/shared/story.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import StatisticWidget from 'components/shared/statisticWidget';
 import StoryImageCutout from 'components/shared/storyImageCutout';
 
 const StorySelector = ({story}) => {
     switch (story?.__typename) {
+        case "paragraph__statistic_widget":
+            return <StatisticWidget statisticData={story} />;
         case "paragraph__story_image_cutout_background":
             return <StoryImageCutout storyData={story} />;
         default:
@@ -27,6 +30,9 @@ export const query = graphql`
     relationships {
       field_story_content {
         __typename
+        ... on paragraph__statistic_widget {
+          ...StatisticWidgetParagraphFragment
+        }
         ... on paragraph__story_image_cutout_background {
           ...StoryImageCutoutParagraphFragment
         }

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -78,7 +78,8 @@ const Widget = ({widget}) => {
     return <ConditionalWrapper 
         condition={widget?.__typename !== "paragraph__yaml_widget" 
             && widget?.__typename !== "paragraph__modal_video_widget" 
-            && widget?.__typename !== "paragraph__story_widget" } 
+            && widget?.__typename !== "paragraph__story_widget"
+            && widget?.__typename !== "paragraph__statistic_widget" } 
         wrapper={children => 
             <PageContainer.SiteContent>
               <PageContainer.ContentArea>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -11,6 +11,7 @@ import PageContainer from 'components/shared/pageContainer';
 import ModalVideo from 'components/shared/modalVideo';
 import PageTabs from 'components/shared/pageTabs';
 import SectionWidgets from 'components/shared/sectionWidgets';
+import StatisticWidget from 'components/shared/statisticWidget';
 import StatsWidget from 'components/shared/statsWidget';
 import Story from 'components/shared/story';
 import YamlWidget from 'components/shared/yamlWidget';
@@ -60,6 +61,8 @@ const WidgetSelector = ({widget}) => {
             </>);
         case "paragraph__section_tabs":
             return <PageTabs pageData={widget} />;
+        case "paragraph__statistic_widget":
+            return <StatisticWidget statisticData={widget} />;
         case "paragraph__stats_widget":
             return <StatsWidget statsWidgetData={widget} />;
         case "paragraph__story_widget":
@@ -121,6 +124,9 @@ export const query = graphql`
     }
     ... on paragraph__section_tabs {
       ...SectionTabsParagraphFragment
+    }
+    ... on paragraph__statistic_widget {
+      ...StatisticWidgetParagraphFragment
     }
     ... on paragraph__stats_widget {
       ...StatsWidgetParagraphFragment


### PR DESCRIPTION
# Summary of changes
- Add new statistics module.

## Frontend
- Add 4 statistics styles: Left Border, Gradient of Solid Colours, Solid Colours, and Light Blue
- Allow StatIcon to pick up the colour from the statistics style

## Backend
- Add Statistics Item paragraph type (contains content for each statistic)
- Add Statistics Widget (New) paragraph type to contain Statistics Items
- Make Statistics Widget available on Basic Page in the Widgets, Section and Story paragraph types
- Add taxonomy type Statistics Styles to hold the available stat styles

# Test Plan

**Multidev:** http://storystat-chug.pantheonsite.io

1. View the page at https://storystat-chug.pantheonsite.io/node/972/edit?destination=/admin/content for an example of statistics in use
2. Create your own statistics example if you wish
3. Check the paragraph permissions
4. Review the page at https://mmtest.gatsbyjs.io/statistic-test

# Caveat
- When releasing the code, we will need to recreate the taxonomy items for Statistics Styles on Live as part of the release