### PR TITLE
Add margin bottom to primary section when secondary appears below in narrow view

### DIFF
--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -94,10 +94,10 @@ function SectionWidgets (props) {
 
         if (secondary.length > 0) {
             if (sectionClasses === "col-md-6") {
-                primaryClass = "col-md-6";
+                primaryClass = "col-md-6 mb-5 mb-md-0";
                 secondaryClass = "col-md-6";
             } else {
-                primaryClass = "col-md-9";
+                primaryClass = "col-md-9 mb-5 mb-md-0";
                 secondaryClass = "col-md-3";
             }
         } else {


### PR DESCRIPTION
# Summary of changes
Add margin bottom to primary section when secondary appears below in narrow view

**Before change:**

<img width="555" alt="image" src="https://user-images.githubusercontent.com/1927902/187999063-977fe943-8669-4259-a1f0-984df20a90b6.png">


**After change:**

<img width="541" alt="image" src="https://user-images.githubusercontent.com/1927902/188001279-7ec53104-9b5f-4f1e-9034-c23303cc557e.png">


## Frontend
Add margin bottom to primary section when secondary appears below in narrow view

## Backend
None

# Test Plan

1. Visit the MM Test build: [https://mmtest.gatsbyjs.io/](https://mmtest.gatsbyjs.io/)
1. View any pages with both primary and secondary sections (e.g. https://mmtest.gatsbyjs.io/lang/commerce/global-leader)
2. In a wider viewport, confirm that there is no margin below the primary section when larger than medium size.
3. In a narrow viewport, confirm that when the secondary section moves below the primary section, there is now padding.

