### PR TITLE
Switch triggers from master to main

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-water-03b355f0f.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-water-03b355f0f.yml
@@ -3,11 +3,11 @@ name: Azure Static Web Apps CI/CD
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
-      - master
+      - main
 
 jobs:
   build_and_deploy_job:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pool:
   demands: npm
 
 trigger:
-  - master
+  - main
 
 resources:
   webhooks:
@@ -23,7 +23,7 @@ schedules:
   displayName: Daily midnight build
   branches:
     include:
-    - master
+    - main
   always: true
 
 steps:


### PR DESCRIPTION
# Summary of changes
Switch pipeline triggers to main.

## Frontend
- If Azure pipelines are being used, triggers should work against the main branch instead of the master branch.

## Backend
None

# Test Plan
Pipelines are not currently used but the change should have no adverse effect on our existing build.

