### PR TITLE
Add check for empty url in menu item

### DIFF
--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -1,3 +1,7 @@
+/***
+ * This component has been customized and adapted from the original Gatsby plugin:
+ * https://github.com/xaviemirmon/gatsby-plugin-drupal-menus
+ ***/
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types";
@@ -61,7 +65,7 @@ const generateMenu = (menuLinks, menuName) => {
             <><uofg-dropdown-menu key={item.drupal_id}>
             <button data-for="menu-button">{item.title}</button>
             <ul data-for="menu-content">
-                <li key={item.drupal_id + `dup`}><a href={item.link.url}>{item.title}</a></li>
+                {item.link.url !== "" && <li key={item.drupal_id + `dup`}><a href={item.link.url}>{item.title}</a></li> }
                 {submenuItems}
             </ul>
             </uofg-dropdown-menu></>


### PR DESCRIPTION
# Summary of changes
Added a condition to not render the first item in a dropdown menu, if it has been set to `<nolink> or <button>`
in Drupal.

## Frontend
Added acknowledgement and condition to headerMenu.js 

## Backend
Menus will need to modified to add `<nolink> or <button>` option as necessary, to avoid duplicate menu items.

# Test Plan
- Uses the https://profiles-chug.pantheonsite.io/ multidev
- Menu https://profiles-chug.pantheonsite.io/admin/structure/menu/manage/president-s-office-main has been modified to have one `<nolink>` item, and one `<button>` item
- Check https://build-e754e286-3c11-42e6-938e-2d3fe9000339.gtsb.io/president - Our Team and Initiatives should not have a duplicate item. Awards & Scholarships has a duplicate since it uses a regular link.
- https://build-e754e286-3c11-42e6-938e-2d3fe9000339.gtsb.io/studentexperience menus should work as before, since the first item in the dropdown has a landing page

