### PR TITLE
Add fallback if no testimonial profile link title

### DIFF
--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -49,7 +49,7 @@ function Testimonials (props) {
 			let testimonialTitle = TestimonialTitle(testimonialNode);
 			let testimonialContent = stripHTMLTags(testimonialNode.body.processed);
 			let testimonialPicture = getImage(testimonialNode.relationships.field_hero_image?.relationships.field_media_image);
-			let testimonialHomeProfileTitle = testimonialNode.field_home_profile?.title;
+			let testimonialHomeProfileTitle = testimonialNode.field_home_profile?.title ?? "Associated Profile";
 			let testimonialHomeProfileLink= testimonialNode.field_home_profile?.uri;
     
 			const testimonialHomeProfile = () => {

--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -49,12 +49,13 @@ function Testimonials (props) {
 			let testimonialTitle = TestimonialTitle(testimonialNode);
 			let testimonialContent = stripHTMLTags(testimonialNode.body.processed);
 			let testimonialPicture = getImage(testimonialNode.relationships.field_hero_image?.relationships.field_media_image);
-			let testimonialHomeProfileTitle = testimonialNode.field_home_profile?.title ?? "Associated Profile";
-			let testimonialHomeProfileLink= testimonialNode.field_home_profile?.uri;
     
 			const testimonialHomeProfile = () => {
-				if (testimonialNode.field_home_profile) {
-					return <a href= {testimonialHomeProfileLink}> {testimonialHomeProfileTitle} </a>
+				let testimonialHomeProfileTitle = (testimonialNode.field_home_profile?.title === "") ? "Associated Profile" : testimonialNode.field_home_profile?.title;
+				let testimonialHomeProfileLink = testimonialNode.field_home_profile?.uri;
+
+				if (testimonialHomeProfileLink) {
+					return <a href= {testimonialHomeProfileLink}>{testimonialHomeProfileTitle}</a>
 				} 
 				return null;
 			};
@@ -71,7 +72,7 @@ function Testimonials (props) {
 						<br />
 						<span className="testimonial-person-desc">{testimonialNode.field_testimonial_person_desc}</span>
 						<br/>
-						{testimonialHomeProfile()}
+						{testimonialNode.field_home_profile && testimonialHomeProfile()}
 					</p>
 				</div>
 		);


### PR DESCRIPTION
# Summary of changes
Updated testimonial slider so it shows "Associated Profile" as the link title if none is provided for the Testimonial profile link.

Before fixing
<img width="737" alt="Screen Shot 2022-11-29 at 4 02 45 PM" src="https://user-images.githubusercontent.com/1927902/204647193-04657f10-d8a0-437c-b46c-becdf8ec78b4.png">

After fixing
<img width="1438" alt="Screen Shot 2022-11-29 at 5 08 01 PM" src="https://user-images.githubusercontent.com/1927902/204659057-ce6d0cad-9509-49bb-987c-f06dda5f5267.png">

## Frontend
Updated testimonial slider so it shows "Associated Profile" as the link title if none is provided for the Testimonial profile link.


## Backend
None

# Test Plan
You can use the following multidev for testing: http://fixtestimon-chug.pantheonsite.io
On that multidev, I've updated the testimonial for Emil Kovacevic so the profile has a URL, but no link text. It should show "Associated Profile" on the /widget-examples page (scroll to the bottom): https://build-ac2aa3f6-2f2f-40d1-943c-844eaf9a84e4.gatsbyjs.io/widget-examples




