### PR TITLE
No banner

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,6 +71,10 @@ html {
     border: none !important;
 }
 
+/* h1 title within page body */
+#main-column h1 { margin-left: 3rem; }
+
+
 /* Custom card styles */
 
 .bg-dark a:not(.btn) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,10 +71,6 @@ html {
     border: none !important;
 }
 
-/* h1 title within page body */
-#main-column h1 { margin-left: 3rem; }
-
-
 /* Custom card styles */
 
 .bg-dark a:not(.btn) {

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -37,7 +37,7 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
             
           { /**** No banner ****/}  
           { !(imageData?.length > 0 || heroWidgets?.length > 0) && 
-              <div className="container ft-container">
+              <div className="container page-container">
                 <div className="row site-content">
                     <div className="content-area">
                         <h1>{pageTitle}</h1>

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -34,7 +34,8 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
         
         { /**** Widgets content ****/}
         <div id="main-column">
-          // no banner  
+            
+          { /**** No banner ****/}  
           { !(imageData?.length > 0 || heroWidgets?.length > 0) && <h1>{pageTitle}</h1> }
 
           {widgets?.map((widget) => <Widget widget={widget} key={widget.drupal_id} />)} 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -14,6 +14,7 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
         <Seo title={pageTitle} description={ogDescription} img={ogImage} imgAlt={ogImageAlt} />
         
         { /**** Header and Title ****/ }
+        { (imageData?.length > 0 || heroWidgets?.length > 0) &&
         <div className={imageData?.length > 0 ? "" : "no-thumb"} id="rotator">
             <Hero imgData={imageData} />
             {heroWidgets && (
@@ -27,11 +28,15 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
                 <h1 className="fancy-title">{pageTitle}</h1>
             </div>
         </div>
+        }
         
         <Breadcrumbs menuName={menuName} nodeID={nodeID} nodeTitle={pageTitle} domains={domains} />
         
         { /**** Widgets content ****/}
         <div id="main-column">
+          // no banner  
+          { !(imageData?.length > 0 || heroWidgets?.length > 0) && <h1>{pageTitle}</h1> }
+
           {widgets?.map((widget) => <Widget widget={widget} key={widget.drupal_id} />)} 
         </div>
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -36,7 +36,7 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
         <div id="main-column">
             
           { /**** No banner ****/}  
-          { !(imageData?.length > 0 || heroWidgets?.length > 0) && <h1>{pageTitle}</h1> }
+          { !(imageData?.length > 0 || heroWidgets?.length > 0) && <div className="container ft-container"><h1>{pageTitle}</h1></div>}
 
           {widgets?.map((widget) => <Widget widget={widget} key={widget.drupal_id} />)} 
         </div>

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -36,7 +36,15 @@ const Page = ({nodeID, pageTitle, ogDescription, ogImage, ogImageAlt, imageData,
         <div id="main-column">
             
           { /**** No banner ****/}  
-          { !(imageData?.length > 0 || heroWidgets?.length > 0) && <div className="container ft-container"><h1>{pageTitle}</h1></div>}
+          { !(imageData?.length > 0 || heroWidgets?.length > 0) && 
+              <div className="container ft-container">
+                <div className="row site-content">
+                    <div className="content-area">
+                        <h1>{pageTitle}</h1>
+                    </div>
+                </div>
+              </div>
+          }
 
           {widgets?.map((widget) => <Widget widget={widget} key={widget.drupal_id} />)} 
         </div>


### PR DESCRIPTION
# Summary of changes
- Remove the empty banner section on the page, when there is no banner media.
-  Show the page title in the body of the page in this case

## Frontend
- Added conditions to show/hide the banner section
- Added css rule 

## Backend
n/a

# Test Plan
- https://build-37f9c7e6-bdf8-4e6f-a191-4846092ad607.gatsbyjs.io/
- mutlidev: https://nobanner-chug.pantheonsite.io
- https://build-37f9c7e6-bdf8-4e6f-a191-4846092ad607.gatsbyjs.io/media-text-test-with-a-long-title-that-can-go-over-a-single-line-onto-the-next-one/ is the test page without a banner. Check other pages to see if the banner is showing as expected

