### PR TITLE
Slate Forms Styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -172,7 +172,7 @@ i.green {color:#4cae3e;}
     display: block;
     width: 100%;
     padding: .375rem .75rem;
-    font-size: 1rem;
+    font-size: 1.8rem;
     font-weight: 400;
     line-height: 1.5;
     color: #212529;
@@ -218,7 +218,7 @@ i.green {color:#4cae3e;}
 
 .ug-slate .form_birthdate .form_responses select {
     flex-wrap: 0 0 auto;
-    width: 30%;
+    width: 33%;
 }
 
 .ug-slate .form_birthdate .form_responses {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,11 +164,15 @@ i.green {color:#4cae3e;}
 /* Slate form styles (pulled from UofG-styles-dist) */
 /* @todo: clean up when time permits */
 
+.ug-slate {
+    width: 75%;
+}
+
 .ug-slate input {
     display: block;
     width: 100%;
     padding: .375rem .75rem;
-    font-size: 1.8rem;
+    font-size: 1rem;
     font-weight: 400;
     line-height: 1.5;
     color: #212529;
@@ -190,7 +194,7 @@ i.green {color:#4cae3e;}
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
 }
 
-/* .ug-slate select {
+.ug-slate select {
     display: block;
     width: 100%;
     padding: .375rem 2.25rem .375rem .75rem;
@@ -212,11 +216,20 @@ i.green {color:#4cae3e;}
     appearance: none;
 }
 
+.ug-slate .form_birthdate .form_responses select {
+    flex-wrap: 0 0 auto;
+    width: 30%;
+}
+
+.ug-slate .form_birthdate .form_responses {
+    display: flex;
+}
+
 .ug-slate select:focus{
     border-color: #86b7fe;
     outline: 0;
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
-} */
+}
 
 .ug-slate .form_button_submit {
     color: #ffffff;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -239,6 +239,12 @@ i.green {color:#4cae3e;}
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
 }
 
+@media (min-width: 1200px) {
+    .ug-slate .form_button_submit {
+        font-size: 2.5rem!important;
+    }
+}
+
 .ug-slate .form_button_submit {
     background-color: #c20430 !important;
     border: 2px solid transparent;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -175,7 +175,7 @@ i.green {color:#4cae3e;}
         width: 75%;
     }
     .ug-slate .form_button_submit {
-        font-size: 2.5rem!important;
+        font-size: 2.5rem !important;
     }
 }
 
@@ -251,7 +251,7 @@ i.green {color:#4cae3e;}
     box-shadow: none !important;
     color: #ffffff;
     display: inline-block !important;
-    font-size: calc(1.375rem + 1.5vw)!important;
+    font-size: calc(1.375rem + 1.5vw);
     font-weight: 400;
     margin-bottom: 1rem;
     margin-top: 1rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,7 +168,7 @@ i.green {color:#4cae3e;}
     display: block;
     width: 100%;
     padding: .375rem .75rem;
-    font-size: 1rem;
+    font-size: 1.8rem;
     font-weight: 400;
     line-height: 1.5;
     color: #212529;
@@ -190,12 +190,12 @@ i.green {color:#4cae3e;}
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
 }
 
-.ug-slate select {
+/* .ug-slate select {
     display: block;
     width: 100%;
     padding: .375rem 2.25rem .375rem .75rem;
     -moz-padding-start: calc(0.75rem - 3px);
-    font-size: 1rem;
+    font-size: 1.8rem;
     font-weight: 400;
     line-height: 1.5;
     color: #212529;
@@ -216,7 +216,7 @@ i.green {color:#4cae3e;}
     border-color: #86b7fe;
     outline: 0;
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
-}
+} */
 
 .ug-slate .form_button_submit {
     color: #ffffff;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,8 +164,16 @@ i.green {color:#4cae3e;}
 /* Slate form styles (pulled from UofG-styles-dist) */
 /* @todo: clean up when time permits */
 
-.ug-slate {
-    width: 75%;
+@media (max-width: 575.98px){
+    .ug-slate .form_button_submit {
+        width: 100%;
+    }
+}
+
+@media (min-width: 992px) {
+    .ug-slate {
+        width: 75%;
+    }   
 }
 
 .ug-slate input {
@@ -232,23 +240,22 @@ i.green {color:#4cae3e;}
 }
 
 .ug-slate .form_button_submit {
-    color: #ffffff;
+    background-color: #c20430 !important;
     border: 2px solid transparent;
+    border-color: #c20430 !important;
     border-radius: 0;
-    padding: 0.75rem 1rem;
-    margin-bottom: 1rem;
-    font-weight: 400;
-    vertical-align: middle;
-    text-align: center;
-    display: inline-block;
-    outline: none !important;
-    outline: 0 !important;
     -webkit-box-shadow: none !important;
     box-shadow: none !important;
-    background-color: #c20430 !important;
-    border-color: #c20430 !important;
+    color: #ffffff;
     display: inline-block !important;
-    color: #fff !important;
+    font-size: calc(1.375rem + 1.5vw)!important;
+    font-weight: 400;
+    margin-bottom: 1rem;
+    padding: 0.75rem 1rem;
+    text-align: center;
+    vertical-align: middle;
+    outline: none !important;
+    outline: 0 !important;
 }
 
 .ug-slate .form_button.active,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -173,7 +173,10 @@ i.green {color:#4cae3e;}
 @media (min-width: 992px) {
     .ug-slate {
         width: 75%;
-    }   
+    }
+    .ug-slate .form_button_submit {
+        font-size: 2.5rem!important;
+    }
 }
 
 .ug-slate input {
@@ -239,12 +242,6 @@ i.green {color:#4cae3e;}
     box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
 }
 
-@media (min-width: 1200px) {
-    .ug-slate .form_button_submit {
-        font-size: 2.5rem!important;
-    }
-}
-
 .ug-slate .form_button_submit {
     background-color: #c20430 !important;
     border: 2px solid transparent;
@@ -257,6 +254,7 @@ i.green {color:#4cae3e;}
     font-size: calc(1.375rem + 1.5vw)!important;
     font-weight: 400;
     margin-bottom: 1rem;
+    margin-top: 1rem;
     padding: 0.75rem 1rem;
     text-align: center;
     vertical-align: middle;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -164,7 +164,7 @@ i.green {color:#4cae3e;}
 /* Slate form styles (pulled from UofG-styles-dist) */
 /* @todo: clean up when time permits */
 
-@media (max-width: 575.98px){
+@media (max-width: 768px){
     .ug-slate .form_button_submit {
         width: 100%;
     }
@@ -255,7 +255,7 @@ i.green {color:#4cae3e;}
     font-weight: 400;
     margin-bottom: 1rem;
     margin-top: 1rem;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 3rem;
     text-align: center;
     vertical-align: middle;
     outline: none !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -159,3 +159,90 @@ i.green {color:#4cae3e;}
     column-width: auto;
     column-count: 4;
 }
+
+
+/* Slate form styles (pulled from UofG-styles-dist) */
+/* @todo: clean up when time permits */
+
+.ug-slate input {
+    display: block;
+    width: 100%;
+    padding: .375rem .75rem;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #212529;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ced4da;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border-radius: .25rem;
+    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+}
+
+.ug-slate input:focus {
+    color: #212529;
+    background-color: #fff;
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
+}
+
+.ug-slate select {
+    display: block;
+    width: 100%;
+    padding: .375rem 2.25rem .375rem .75rem;
+    -moz-padding-start: calc(0.75rem - 3px);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #212529;
+    background-color: #fff;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right .75rem center;
+    background-size: 16px 12px;
+    border: 1px solid #ced4da;
+    border-radius: .25rem;
+    transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+
+.ug-slate select:focus{
+    border-color: #86b7fe;
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
+}
+
+.ug-slate .form_button_submit {
+    color: #ffffff;
+    border: 2px solid transparent;
+    border-radius: 0;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-weight: 400;
+    vertical-align: middle;
+    text-align: center;
+    display: inline-block;
+    outline: none !important;
+    outline: 0 !important;
+    -webkit-box-shadow: none !important;
+    box-shadow: none !important;
+    background-color: #c20430 !important;
+    border-color: #c20430 !important;
+    display: inline-block !important;
+    color: #fff !important;
+}
+
+.ug-slate .form_button.active,
+.ug-slate .form_button:active,
+.ug-slate .form_button_submit:hover,
+.ug-slate .form_button_submit:focus {
+    background-color: #900324!important;
+    border-color: #900324!important;
+    color: #fff!important;
+}


### PR DESCRIPTION
# Summary of changes
Add Slate Forms styles for select, input and button (using the UG version of Bootstrap styles as a base)

## Frontend
- Added Slate Forms styles for select, input and button
- Felt slightly ashamed for copying them over in the quickest manner possible (without cleaning them properly)
- Promised myself I would clean them up some day

## Backend
- None

# Test Plan

View [https://mmtest.gatsbyjs.io/lindas-test-page](https://mmtest.gatsbyjs.io/lindas-test-page/)

