### PR TITLE
Rebuild Economic Impact Report with widgets

### DIFF
--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -58,43 +58,43 @@ const render = ({ title, lead, body_html, testimonial, aside }) => (
 
 const query = graphql`
   query {
-    economicImpactYaml(yamlId: {eq: "economic_impact_national_story"}) {
-        id
+    blockContentYamlBlock(field_yaml_id: {eq: "economic_impact_national_story"}) {
+      id
+      title
+      lead
+      body_html
+      testimonial {
+        quote
+        source {
+          name
+          desc
+          pronouns
+          image {
+            src {
+              childImageSharp {
+                gatsbyImageData
+              }
+            }
+            alt
+          }
+        }
+      }
+      aside {
         title
-        lead
-        body_html
-        testimonial {
-            quote
-            source {
-                name
-                desc
-                pronouns
-                image {
-                    src {
-                        childImageSharp {
-                            gatsbyImageData
-                          }
-                    }
-                    alt
-                }
+        body
+        image {
+          src {
+            childImageSharp {
+                gatsbyImageData
             }
+          }
+          alt
         }
-        aside {
-            title
-            body
-            image {
-                src {
-                    childImageSharp {
-                        gatsbyImageData
-                    }
-                }
-                alt
-            }
-        }
+      }
     }
   }
 `
 
 export default function EconImpactNationalStory () {
-  return <StaticQuery query={query} render={({economicImpactYaml}) => render(economicImpactYaml)} />
+  return <StaticQuery query={query} render={({blockContentYamlBlock}) => render(blockContentYamlBlock)} />
 }

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -81,28 +81,30 @@ const query = graphql`
       id
       field_yaml_id
       field_yaml_map
-      field_yaml_files {
-        id
-        name
-        relationships {
-          field_media_image {
-            gatsbyImage(
-              width: 1400 
-              placeholder: BLURRED
-              layout: CONSTRAINED
-              cropFocus: CENTER
-            )
-            relationships {
-              media__image {
-                field_media_image {
-                  alt
+      relationships {  
+        field_yaml_files {
+          id
+          name
+          relationships {
+            field_media_image {
+                gatsbyImage(
+                  width: 1400 
+                  placeholder: BLURRED
+                  layout: CONSTRAINED
+                  cropFocus: CENTER
+                )
+                relationships {
+                  media__image {
+                    field_media_image {
+                      alt
+                    }
+                  }
                 }
-              }
             }
-          }
-        }        
-        drupal_internal__mid
-      }        
+          }        
+          drupal_internal__mid
+        }
+      }
     }
   }
 `

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -16,25 +16,6 @@ const NationalImpactAside = ({aside}) => (
     </div>
 )
 
-const NationalImpactTestimony = ({ testimonial }) => (
-    <div className="mt-5 me-3 pb-5">
-        <Row className="justify-content-center g-5">
-            <Col xs={5} sm={4} md={3}>
-                <GatsbyImage image={getImage(yamlFiles[testimonial.source.image.mid]?.src)} alt={yamlFiles[testimonial.source.image.mid]?.alt ?? ""} imgClassName="rounded-circle" />
-            </Col>
-            <Col sm={8} md={9} className="ps-5 fs-2">
-                <p className="fs-1 text-dark">
-                    <i className="fad fa-quote-left pe-2 uog-blue" aria-hidden="true" /> 
-                        <em>{testimonial.quote}</em>
-                    <i className="fad fa-quote-right ps-2 uog-blue" aria-hidden="true" />
-                </p>
-                <p className="author"><strong>{testimonial.source.name}</strong> {testimonial.source.pronouns}
-                <br /><em>{testimonial.source.desc}</em></p>
-            </Col>
-        </Row>
-    </div>
-)
-
 const render = ({ field_yaml_map, relationships }) => {
   let yamlMap;
   let yamlFiles = {};
@@ -61,7 +42,25 @@ const render = ({ field_yaml_map, relationships }) => {
                         <h2 id="national-impact">{yamlMap.title}</h2>
                         <p className="text-dark text-uppercase"><strong>{yamlMap.lead}</strong></p>
                         <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}}></div>
-                        <NationalImpactTestimony testimonial={yamlMap.testimonial} />
+                            <div className="mt-5 me-3 pb-5">
+                                <Row className="justify-content-center g-5">
+                                <Col xs={5} sm={4} md={3}>
+                                    <GatsbyImage 
+                                      image={getImage(yamlFiles[yamlMap.testimonial.source.image.mid]?.src)} 
+                                      alt={yamlFiles[yamlMap.testimonial.source.image.mid]?.alt ?? ""} imgClassName="rounded-circle" 
+                                    />                                    
+                                </Col>
+                                <Col sm={8} md={9} className="ps-5 fs-2">
+                                    <p className="fs-1 text-dark">
+                                        <i className="fad fa-quote-left pe-2 uog-blue" aria-hidden="true" /> 
+                                            <em>{yamlMap.testimonial.quote}</em>
+                                        <i className="fad fa-quote-right ps-2 uog-blue" aria-hidden="true" />
+                                    </p>
+                                    <p className="author"><strong>{yamlMap.testimonial.source.name}</strong> {yamlMap.testimonial.source.pronouns}
+                                    <br /><em>{yamlMap.testimonial.source.desc}</em></p>
+                                </Col>
+                            </Row>
+                        </div>
                     </Col>
                     <Col md={6} className="d-flex position-relative p-0">
                         <GatsbyImage image={getImage(yamlFiles[yamlMap.aside.image.mid]?.src)} alt={yamlFiles[yamlMap.aside.image.mid]?.alt ?? ""} className="position-absolute top-0 end-0" />

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -95,6 +95,6 @@ const query = graphql`
   }
 `
 
-export default function EconImpactNationalImpact () {
+export default function EconImpactNationalStory () {
   return <StaticQuery query={query} render={({economicImpactYaml}) => render(economicImpactYaml)} />
 }

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -1,0 +1,100 @@
+import React from "react"
+import { StaticQuery, graphql } from "gatsby"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
+import { Container, Row, Col } from "react-bootstrap"
+
+const NationalImpactAside = ({aside}) => (
+    <div className="card bg-dark border-0 text-white p-5 rounded-0 align-self-center me-5">
+        <div className="card-body px-5">
+            <h3 className="mt-0 text-white h1">{aside.title}</h3>
+            <div className="card-text fs-3">
+                {aside.body.map((paragraph, index) => <p key={`intro-text-${index}`}>{paragraph}</p>)}
+            </div>
+        </div>
+    </div>
+)
+
+const NationalImpactTestimony = ({ testimonial }) => (
+    <div className="mt-5 me-3 pb-5">
+        <Row className="justify-content-center g-5">
+            <Col xs={5} sm={4} md={3}>
+                <GatsbyImage image={getImage(testimonial.source.image.src)} alt={testimonial.source.image.alt} imgClassName="rounded-circle" />
+            </Col>
+            <Col sm={8} md={9} className="ps-5 fs-2">
+                <p className="fs-1 text-dark">
+                    <i className="fad fa-quote-left pe-2 uog-blue" aria-hidden="true" /> 
+                        <em>{testimonial.quote}</em>
+                    <i className="fad fa-quote-right ps-2 uog-blue" aria-hidden="true" />
+                </p>
+                <p className="author"><strong>{testimonial.source.name}</strong> {testimonial.source.pronouns}
+                <br /><em>{testimonial.source.desc}</em></p>
+            </Col>
+        </Row>
+    </div>
+)
+
+const render = ({ title, lead, body_html, testimonial, aside }) => (
+    <>
+        <div className="d-flex flex-column bg-light">
+            <div className="full-width-container">
+                <Container className="page-container pe-0">
+                    <Row className="site-content mx-4 py-0 pe-0">
+                        <Col md={6} className="pe-5 pt-4">
+                            <h2 id="national-impact">{title}</h2>
+                            <p className="text-dark text-uppercase"><strong>{lead}</strong></p>
+                            <div dangerouslySetInnerHTML={{__html: body_html}}></div>
+                            <NationalImpactTestimony testimonial={testimonial} />
+                        </Col>
+                        <Col md={6} className="d-flex position-relative p-0">
+                            <GatsbyImage image={getImage(aside.image.src)} alt={aside.image.alt} className="position-absolute top-0 end-0" />
+                            <NationalImpactAside aside={aside} />    
+                        </Col>
+                    </Row>
+                </Container>
+            </div>
+        </div>
+    </>
+)
+
+const query = graphql`
+  query {
+    economicImpactYaml(yamlId: {eq: "economic_impact_national_story"}) {
+        id
+        title
+        lead
+        body_html
+        testimonial {
+            quote
+            source {
+                name
+                desc
+                pronouns
+                image {
+                    src {
+                        childImageSharp {
+                            gatsbyImageData
+                          }
+                    }
+                    alt
+                }
+            }
+        }
+        aside {
+            title
+            body
+            image {
+                src {
+                    childImageSharp {
+                        gatsbyImageData
+                    }
+                }
+                alt
+            }
+        }
+    }
+  }
+`
+
+export default function EconImpactNationalImpact () {
+  return <StaticQuery query={query} render={({economicImpactYaml}) => render(economicImpactYaml)} />
+}

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -20,7 +20,6 @@ const NationalImpactTestimony = ({ testimonial }) => (
     <div className="mt-5 me-3 pb-5">
         <Row className="justify-content-center g-5">
             <Col xs={5} sm={4} md={3}>
-                <GatsbyImage image={getImage(testimonial.source.image.src)} alt={testimonial.source.image.alt} imgClassName="rounded-circle" />
                 <GatsbyImage image={getImage(yamlFiles[testimonial.source.image.mid]?.src)} alt={yamlFiles[testimonial.source.image.mid]?.alt ?? ""} imgClassName="rounded-circle" />
             </Col>
             <Col sm={8} md={9} className="ps-5 fs-2">

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -81,24 +81,28 @@ const query = graphql`
       id
       field_yaml_id
       field_yaml_map
-      relationships {
-        field_media_image {
-          gatsbyImage(
-            width: 1400 
-            placeholder: BLURRED
-            layout: CONSTRAINED
-            cropFocus: CENTER
-          )
-          relationships {
-            media__image {
-              field_media_image {
-                alt
+      field_yaml_files {
+        id
+        name
+        relationships {
+          field_media_image {
+            gatsbyImage(
+              width: 1400 
+              placeholder: BLURRED
+              layout: CONSTRAINED
+              cropFocus: CENTER
+            )
+            relationships {
+              media__image {
+                field_media_image {
+                  alt
+                }
               }
             }
           }
-        }
+        }        
         drupal_internal__mid
-      }      
+      }        
     }
   }
 `

--- a/src/components/blocks/economic-impact/national-impact-story.js
+++ b/src/components/blocks/economic-impact/national-impact-story.js
@@ -3,6 +3,8 @@ import { StaticQuery, graphql } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import { Container, Row, Col } from "react-bootstrap"
 
+const yaml = require('js-yaml');
+
 const NationalImpactAside = ({aside}) => (
     <div className="card bg-dark border-0 text-white p-5 rounded-0 align-self-center me-5">
         <div className="card-body px-5">
@@ -19,6 +21,7 @@ const NationalImpactTestimony = ({ testimonial }) => (
         <Row className="justify-content-center g-5">
             <Col xs={5} sm={4} md={3}>
                 <GatsbyImage image={getImage(testimonial.source.image.src)} alt={testimonial.source.image.alt} imgClassName="rounded-circle" />
+                <GatsbyImage image={getImage(yamlFiles[testimonial.source.image.mid]?.src)} alt={yamlFiles[testimonial.source.image.mid]?.alt ?? ""} imgClassName="rounded-circle" />
             </Col>
             <Col sm={8} md={9} className="ps-5 fs-2">
                 <p className="fs-1 text-dark">
@@ -33,64 +36,69 @@ const NationalImpactTestimony = ({ testimonial }) => (
     </div>
 )
 
-const render = ({ title, lead, body_html, testimonial, aside }) => (
-    <>
-        <div className="d-flex flex-column bg-light">
-            <div className="full-width-container">
-                <Container className="page-container pe-0">
-                    <Row className="site-content mx-4 py-0 pe-0">
-                        <Col md={6} className="pe-5 pt-4">
-                            <h2 id="national-impact">{title}</h2>
-                            <p className="text-dark text-uppercase"><strong>{lead}</strong></p>
-                            <div dangerouslySetInnerHTML={{__html: body_html}}></div>
-                            <NationalImpactTestimony testimonial={testimonial} />
-                        </Col>
-                        <Col md={6} className="d-flex position-relative p-0">
-                            <GatsbyImage image={getImage(aside.image.src)} alt={aside.image.alt} className="position-absolute top-0 end-0" />
-                            <NationalImpactAside aside={aside} />    
-                        </Col>
-                    </Row>
-                </Container>
-            </div>
+const render = ({ field_yaml_map, relationships }) => {
+  let yamlMap;
+  let yamlFiles = {};
+  relationships.field_yaml_files.forEach(file => {
+    yamlFiles[file.drupal_internal__mid] = {
+      src: file.relationships?.field_media_image,
+      alt: file.relationships?.field_media_image?.relationships.media__image[0].field_media_image.alt,
+    }
+  });
+
+  try {
+    yamlMap = yaml.load(field_yaml_map);
+  } catch (e) {
+    console.log(e);
+    return null;
+  }
+
+  return (<>
+    <div className="d-flex flex-column bg-light">
+        <div className="full-width-container">
+            <Container className="page-container pe-0">
+                <Row className="site-content mx-4 py-0 pe-0">
+                    <Col md={6} className="pe-5 pt-4">
+                        <h2 id="national-impact">{yamlMap.title}</h2>
+                        <p className="text-dark text-uppercase"><strong>{yamlMap.lead}</strong></p>
+                        <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}}></div>
+                        <NationalImpactTestimony testimonial={yamlMap.testimonial} />
+                    </Col>
+                    <Col md={6} className="d-flex position-relative p-0">
+                        <GatsbyImage image={getImage(yamlFiles[yamlMap.aside.image.mid]?.src)} alt={yamlFiles[yamlMap.aside.image.mid]?.alt ?? ""} className="position-absolute top-0 end-0" />
+                        <NationalImpactAside aside={yamlMap.aside} />    
+                    </Col>
+                </Row>
+            </Container>
         </div>
-    </>
-)
+    </div>
+    </>)
+}
 
 const query = graphql`
   query {
-    blockContentYamlBlock(field_yaml_id: {eq: "economic_impact_national_story"}) {
+    blockContentYamlBlock(field_yaml_id: {glob: "economic_impact_national_story"}) {
       id
-      title
-      lead
-      body_html
-      testimonial {
-        quote
-        source {
-          name
-          desc
-          pronouns
-          image {
-            src {
-              childImageSharp {
-                gatsbyImageData
+      field_yaml_id
+      field_yaml_map
+      relationships {
+        field_media_image {
+          gatsbyImage(
+            width: 1400 
+            placeholder: BLURRED
+            layout: CONSTRAINED
+            cropFocus: CENTER
+          )
+          relationships {
+            media__image {
+              field_media_image {
+                alt
               }
             }
-            alt
           }
         }
-      }
-      aside {
-        title
-        body
-        image {
-          src {
-            childImageSharp {
-                gatsbyImageData
-            }
-          }
-          alt
-        }
-      }
+        drupal_internal__mid
+      }      
     }
   }
 `

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -15,21 +15,23 @@ const render = ({ field_yaml_map }) => {
   } 
   
   return (<>
-    <h3 className="mt-0 text-dark text-uppercase">{yamlMap.title}</h3>
-    <div className="border-5 border-start px-4 mb-5">
-        <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}}></div>
-        {yamlMap.video && 
-          <ModalVideo 
-            id={yamlMap.video.id} 
-            src={yamlMap.video.url} 
-            title={yamlMap.video.title} 
-            transcript={yamlMap.video.transcript} 
-            modalButton = {
-                <button type="button" className="btn btn-outline-info my-4">
-                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {yamlMap.video.title}</span>
-                </button>
-            }
-        />}
+    <div className="mt-4">
+        <h3 className="fs-3 mt-0 text-dark text-uppercase">{yamlMap.title}</h3>
+        <div className="uog-border-blue px-4 mb-5">
+            <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}}></div>
+            {yamlMap.video && 
+              <ModalVideo 
+                id={yamlMap.video.id} 
+                src={yamlMap.video.url} 
+                title={yamlMap.video.title} 
+                transcript={yamlMap.video.transcript} 
+                modalButton = {
+                    <button type="button" className="btn btn-outline-info my-4">
+                        <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {yamlMap.video.title}</span>
+                    </button>
+                }
+            />}
+        </div>
     </div>
   </>)
 }

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -15,18 +15,18 @@ const render = ({ field_yaml_map }) => {
   } 
   
   return (<>
-    <h3 className="mt-0 text-dark text-uppercase">{field_yaml_map.title}</h3>
+    <h3 className="mt-0 text-dark text-uppercase">{yamlMap.title}</h3>
     <div className="border-5 border-start px-4 mb-5">
-        <div dangerouslySetInnerHTML={{__html: field_yaml_map.body_html}}></div>
-        {field_yaml_map.video && 
+        <div dangerouslySetInnerHTML={{__html: yamlMap.body_html}}></div>
+        {yamlMap.video && 
           <ModalVideo 
-            id={field_yaml_map.video.id} 
-            src={field_yaml_map.video.url} 
-            title={field_yaml_map.video.title} 
-            transcript={field_yaml_map.video.transcript} 
+            id={yamlMap.video.id} 
+            src={yamlMap.video.url} 
+            title={yamlMap.video.title} 
+            transcript={yamlMap.video.transcript} 
             modalButton = {
                 <button type="button" className="btn btn-outline-info my-4">
-                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {field_yaml_map.video.title}</span>
+                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {yamlMap.video.title}</span>
                 </button>
             }
         />}

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -18,7 +18,7 @@ const render = ({ field_yaml_map }) => {
     <h3 className="mt-0 text-dark text-uppercase">{field_yaml_map.title}</h3>
     <div className="border-5 border-start px-4 mb-5">
         <div dangerouslySetInnerHTML={{__html: field_yaml_map.body_html}}></div>
-        {video && 
+        {field_yaml_map.video && 
           <ModalVideo 
             id={field_yaml_map.video.id} 
             src={field_yaml_map.video.url} 

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -2,41 +2,43 @@ import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import ModalVideo from "components/shared/modalVideo"
 
-const render = ({ title, body_html, video }) => (   
-  <>
-    <h3 className="mt-0 text-dark text-uppercase">{title}</h3>
+const yaml = require('js-yaml');
+
+const render = ({ field_yaml_map }) => {
+  let yamlMap;
+
+  try {
+    yamlMap = yaml.load(field_yaml_map);
+  } catch (e) {
+    console.log(e);
+    return null;
+  } 
+  
+  return (<>
+    <h3 className="mt-0 text-dark text-uppercase">{field_yaml_map.title}</h3>
     <div className="border-5 border-start px-4 mb-5">
-        <div dangerouslySetInnerHTML={{__html: body_html}}></div>
+        <div dangerouslySetInnerHTML={{__html: field_yaml_map.body_html}}></div>
         {video && 
           <ModalVideo 
-            id={video.id} 
-            src={video.url} 
-            title={video.title} 
-            transcript={video.transcript} 
+            id={field_yaml_map.video.id} 
+            src={field_yaml_map.video.url} 
+            title={field_yaml_map.video.title} 
+            transcript={field_yaml_map.video.transcript} 
             modalButton = {
                 <button type="button" className="btn btn-outline-info my-4">
-                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
+                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {field_yaml_map.video.title}</span>
                 </button>
             }
         />}
     </div>
-  </>
-)
-
+  </>)
+}
 const query = graphql`
   query {
     blockContentYamlBlock(yamlId: {eq: "economic_impact_provincial_onehealth"}) {
       id
-      title
-      body_html
-      video {
-        id
-        type
-        title
-        url
-        transcript
-        captions
-      }
+      field_yaml_id
+      field_yaml_map
     }
   }
 `

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -35,7 +35,7 @@ const render = ({ field_yaml_map }) => {
 }
 const query = graphql`
   query {
-    blockContentYamlBlock(yamlId: {eq: "economic_impact_provincial_onehealth"}) {
+    blockContentYamlBlock(field_yaml_id: {glob: "economic_impact_provincial_onehealth"}) {
       id
       field_yaml_id
       field_yaml_map

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -1,0 +1,46 @@
+import React from "react"
+import { StaticQuery, graphql } from "gatsby"
+import ModalVideo from "components/shared/modalVideo"
+
+const render = ({ title, body_html, video }) => (   
+  <>
+    <h3 className="mt-0 text-dark text-uppercase">{title}</h3>
+    <div className="border-5 border-start px-4 mb-5">
+        <div dangerouslySetInnerHTML={{__html: body_html}}></div>
+        {video && 
+          <ModalVideo 
+            id={video.id} 
+            src={video.url} 
+            title={video.title} 
+            transcript={video.transcript} 
+            modalButton = {
+                <button type="button" className="btn btn-outline-info my-4">
+                    <i className="fa-solid fa-play"></i> Watch Video<span className="visually-hidden">: {video.title}</span>
+                </button>
+            }
+        />}
+    </div>
+  </>
+)
+
+const query = graphql`
+  query {
+    economicImpactYaml(yamlId: {eq: "economic_impact_provincial_onehealth"}) {
+        id
+        title
+        body_html
+        video {
+          id
+          type
+          title
+          url
+          transcript
+          captions
+        }
+    }
+  }
+`
+
+export default function EconImpactProvincialImpactOnehealth () {
+  return <StaticQuery query={query} render={({economicImpactYaml}) => render(economicImpactYaml)} />
+}

--- a/src/components/blocks/economic-impact/provincial-impact-onehealth.js
+++ b/src/components/blocks/economic-impact/provincial-impact-onehealth.js
@@ -25,22 +25,22 @@ const render = ({ title, body_html, video }) => (
 
 const query = graphql`
   query {
-    economicImpactYaml(yamlId: {eq: "economic_impact_provincial_onehealth"}) {
+    blockContentYamlBlock(yamlId: {eq: "economic_impact_provincial_onehealth"}) {
+      id
+      title
+      body_html
+      video {
         id
+        type
         title
-        body_html
-        video {
-          id
-          type
-          title
-          url
-          transcript
-          captions
-        }
+        url
+        transcript
+        captions
+      }
     }
   }
 `
 
 export default function EconImpactProvincialImpactOnehealth () {
-  return <StaticQuery query={query} render={({economicImpactYaml}) => render(economicImpactYaml)} />
+  return <StaticQuery query={query} render={({blockContentYamlBlock}) => render(blockContentYamlBlock)} />
 }

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -249,7 +249,7 @@ export const query = graphql`
     relationships {
       field_media_image {
         publicUrl
-        gatsbyImage(width: 800, placeholder: BLURRED, layout: CONSTRAINED)
+        gatsbyImage(width: 1000, placeholder: BLURRED, layout: CONSTRAINED)
       }
     }
   }

--- a/src/components/shared/storyImageCutout.js
+++ b/src/components/shared/storyImageCutout.js
@@ -149,7 +149,7 @@ export const query = graphql`
               gatsbyImage(
                 layout: CONSTRAINED,
                 placeholder: BLURRED,
-                height: 540,
+                width: 1000,
               )
             }
           }

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -17,7 +17,7 @@ import StatsWidget from 'components/shared/statsWidget';
 import Story from 'components/shared/story';
 import TestimonialSlider from 'components/shared/testimonialSlider';
 import YamlWidget from 'components/shared/yamlWidget';
-import { ConditionalWrapper } from 'utils/ug-utils';
+import { ConditionalWrapper, slugify } from 'utils/ug-utils';
 
 const WidgetSelector = ({widget}) => {
     switch (widget?.__typename) {
@@ -58,7 +58,7 @@ const WidgetSelector = ({widget}) => {
             : null;
         case "paragraph__section":
             return (<>
-              {widget.field_section_title && <h2>{widget.field_section_title}</h2>}
+              {widget.field_section_title && <h2 id={slugify(widget.field_section_title)}>{widget.field_section_title}</h2>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/yamlWidget.js
+++ b/src/components/shared/yamlWidget.js
@@ -3,6 +3,8 @@ import { graphql } from 'gatsby';
 
 // @todo - add index of components in components/blocks and import all in one line
 // until then, import each component manually below
+import EconImpactNationalStory from 'components/blocks/economic-impact/national-impact-story';
+import EconImpactProvincialImpactOnehealth from 'components/blocks/economic-impact/provincial-impact-onehealth';
 import InternationalStatsGlobal from 'components/blocks/international/international-stats-global';
 import InternationalExploreThingsToKnow from 'components/blocks/international/international-things-to-know';
 import InternationalExploreButtons from 'components/blocks/international/international-explore-btns';
@@ -20,6 +22,8 @@ const YamlWidget = (props) => {
 
     // add new custom components to conditional rendering below
     return ({
+        'economic_impact_national_story': <EconImpactNationalStory />,
+        'economic_impact_provincial_onehealth': <EconImpactProvincialImpactOnehealth />,
         'international_stats_global_impact': <InternationalStatsGlobal />,
         'international_explore_things_to_know': <InternationalExploreThingsToKnow />,
         'international_explore_btns': <InternationalExploreButtons />,

--- a/src/components/shared/yamlWidget.js
+++ b/src/components/shared/yamlWidget.js
@@ -9,10 +9,8 @@ import InternationalExploreButtons from 'components/blocks/international/interna
 import InternationalExploreGrid from 'components/blocks/international/international-explore-grid';
 import InternationalTalkCurrentStudent from 'components/blocks/international/international-talk-current-student';
 import InternationalExploreLead from 'components/blocks/international/international-explore-lead';
-import LangBcommStats from 'components/blocks/lang/lang-bcomm-stats';
 import LangBcommQuote from 'components/blocks/lang/lang-bcomm-quote';
 import LangBcommSupportiveCommunity from 'components/blocks/lang/lang-bcomm-supportive-community';
-import LangBcommStatsBordered from 'components/blocks/lang/lang-bcomm-stats-bordered';
 import LangBcommFeatureExperience from 'components/blocks/lang/lang-bcomm-feature-experience';
 import LangBcommStudentBlog from 'components/blocks/lang/lang-bcomm-student-blog';
 import SouthAsiaExploreGrid from 'components/blocks/canada/south-asia-explore-grid';
@@ -29,10 +27,8 @@ const YamlWidget = (props) => {
         'international_talk_current_student':<InternationalTalkCurrentStudent />,
         'international_talk_current_student_blue':<InternationalTalkCurrentStudent background="#F4F7FA" />,
         'international_explore_lead':<InternationalExploreLead />,
-        'lang_bcomm_stats':<LangBcommStats />,
         'lang_bcomm_quote':<LangBcommQuote />,
         'lang_bcomm_supportive_community':<LangBcommSupportiveCommunity />,
-        'lang_bcomm_stats_bordered':<LangBcommStatsBordered />,
         'lang_bcomm_feature_experience':<LangBcommFeatureExperience />,
         'lang_bcomm_student_blog':<LangBcommStudentBlog />,
         'lang_bcomm_student_blog_blue':<LangBcommStudentBlog background="#F4F7FA" />,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -115,15 +115,16 @@ html {
 .bg-dark h4 {
     color: var(--off-white) !important;
 }
+.uog-blue {color: var(--uog-blue);}
 .uog-blue-muted {background:#edf2f5;}
 i.green {color:#4cae3e;}
 
-.uog-tertiary-color1 {color:#0d6efd;}
-.uog-tertiary-color2 {color:#6610f2;}
-.uog-tertiary-color3 {color:#d63384;}
-.uog-tertiary-color4 {color:#fd7e14;}
-.uog-tertiary-color5 {color:#198754;}
-.uog-tertiary-color6 {color:#20c997;}
+.uog-tertiary-color1 {color:#0d6efd;} /* Brandeis Blue */
+.uog-tertiary-color2 {color:#6610f2;} /* Electric Indigo */
+.uog-tertiary-color3 {color:#d63384;} /* Deep Cerise */
+.uog-tertiary-color4 {color:#fd7e14;} /* Pumpkin */
+.uog-tertiary-color5 {color:#198754;} /* Salem (green) */
+.uog-tertiary-color6 {color:#20c997;} /* Mountain Meadow (green) */
 
 .card .uog-card-border {
     border-left: 1rem solid var(--uog-red);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -173,3 +173,9 @@ i.green {color:#4cae3e;}
     column-width: auto;
     column-count: 4;
 }
+
+/* List style overrides */
+.main-container .site-content ul.list-unstyled li:before, 
+.page-container .site-content ul.list-unstyled li:before {
+	all: unset;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -116,7 +116,7 @@ html {
     color: var(--off-white) !important;
 }
 .uog-blue {color: var(--uog-blue);}
-.uog-blue-muted {background:#edf2f5;}
+.uog-blue-muted {background: #f5f7fa;}
 i.green {color:#4cae3e;}
 
 .uog-tertiary-color1 {color:#0d6efd;} /* Brandeis Blue */
@@ -125,6 +125,19 @@ i.green {color:#4cae3e;}
 .uog-tertiary-color4 {color:#fd7e14;} /* Pumpkin */
 .uog-tertiary-color5 {color:#198754;} /* Salem (green) */
 .uog-tertiary-color6 {color:#20c997;} /* Mountain Meadow (green) */
+
+.uog-border-red {
+	border-left: 1rem solid var(--uog-red);
+}
+.uog-border-yellow {
+	border-left: 1rem solid var(--uog-yellow);
+}
+.uog-border-black {
+	border-left: 1rem solid var(--black);
+}
+.uog-border-blue {
+	border-left: 1rem solid var(--uog-blue);
+}
 
 .card .uog-card-border {
     border-left: 1rem solid var(--uog-red);

--- a/src/utils/ug-utils.js
+++ b/src/utils/ug-utils.js
@@ -54,6 +54,21 @@ function setHeadingLevel(headingLevel) {
 	return selectedHeading;
 }
 
+function slugify(string) {
+    const a = 'àáâäæãåāăąçćčđďèéêëēėęěğǵḧîïíīįìłḿñńǹňôöòóœøōõőṕŕřßśšşșťțûüùúūǘůűųẃẍÿýžźż·/_,:;'
+    const b = 'aaaaaaaaaacccddeeeeeeeegghiiiiiilmnnnnoooooooooprrsssssttuuuuuuuuuwxyyzzz------'
+    const p = new RegExp(a.split('').join('|'), 'g')
+
+    return string.toString().toLowerCase()
+    .replace(/\s+/g, '-') // Replace spaces with -
+    .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
+    .replace(/&/g, '-and-') // Replace & with 'and'
+    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
+    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/^-+/, '') // Trim - from start of text
+    .replace(/-+$/, '') // Trim - from end of text
+}
+
 function sortLastModifiedDates(dates) {
 	return dates.slice().flat().sort();
 }
@@ -71,6 +86,7 @@ export {
 	fontAwesomeIconColour,
 	getNextHeadingLevel,
 	setHeadingLevel,
+    slugify,
 	sortLastModifiedDates,
 	stripHTMLTags,
     ConditionalWrapper


### PR DESCRIPTION
# Summary of changes
Rebuild the Economic Impact Report as a basic page using widgets so it no longer needs to be hard-coded within this repository

## Frontend
- add new yaml components `national-impact-story.js` and `provincial-impact-onehealth.js`
- reference new components in `yamlWidget.js` and remove unused ones 
- fix `gatsbyImage` width in `mediaText.js` and `storyImageCutout.js` so images are resized correctly
- add `slugify` function to `ug-utils.js`
- add `id` to `Section Title` to enable use of anchor links
- add new rules to `global.css` to address formatting requirements not provided by default Bootstrap classes

## Backend
- add new text format `Hardcore HTML` to override CKeditor limitations (e.g. automatic removal of empty `<i>` tags) and limit its use to the Administrator role
- add `economic_impact_national_story` and `economic_impact_provincial_onehealth` Yaml blocks

# Test Plan
- Backend: https://api.liveugconthub.uoguelph.dev/impact-report-2
- Frontend: https://tqtest.gatsbyjs.io/impact-report-2/
- Compare the new version to https://www.uoguelph.ca/grce/impact-report/ and ensure they match as much as possible
- Compare https://tqtest.gatsbyjs.io/lang/commerce/global-leader/ to https://www.uoguelph.ca/lang/commerce/global-leader/ and ensure the Austin Armstrong photos are the same height

## Known issues
- The hero image on the new Impact Report is not as wide as the original due to theme defaults
- The pale blue background on the https://www.uoguelph.ca/grce/impact-report/#research-training-innovation section cannot be replicated in the content hub at this time (unless a custom Yaml block is used, though it would seem to be overkill for such a trivial issue)
- The image for the Heather Pollock quote is taller and paler than the original due to component defaults (it will need to be replaced with a version without a baked-in white overlay)

