### PR TITLE
Fix disabled parent menu link bug

### DIFF
--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -8,9 +8,9 @@ import PropTypes from "prop-types";
 
 const createMenuHierarchy = (menuData, menuName) => {
   let tree = [],
-     mappedArr = {},
-     arrElem,
-     mappedElem
+      mappedArr = {},
+      arrElem,
+      mappedElem
 
   // First map the nodes of the array to an object -> create a hash table.
   for (let i = 0, len = menuData.length; i < len; i++) {
@@ -29,8 +29,12 @@ const createMenuHierarchy = (menuData, menuName) => {
     if (mappedArr.hasOwnProperty(id)) {
       mappedElem = mappedArr[id]
       // If the element is not at the root level, add it to its parent array of children.
-      if (mappedElem.drupal_parent_menu_item && mappedArr[mappedElem.drupal_parent_menu_item]['children'] != null) {
-        mappedArr[mappedElem.drupal_parent_menu_item]['children'].push(mappedElem)
+      if (mappedElem.drupal_parent_menu_item) {
+        let parentElem = mappedArr[mappedElem.drupal_parent_menu_item]
+        // Check if the parent element is enabled before adding the current element as its child
+        if (parentElem?.enabled === true) {
+          parentElem['children'].push(mappedElem)
+        }
       }
       // If the element is at the root level, add it to first level elements array.
       else {

--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -29,7 +29,7 @@ const createMenuHierarchy = (menuData, menuName) => {
     if (mappedArr.hasOwnProperty(id)) {
       mappedElem = mappedArr[id]
       // If the element is not at the root level, add it to its parent array of children.
-      if (mappedElem.drupal_parent_menu_item) {
+      if (mappedElem.drupal_parent_menu_item && mappedArr[mappedElem.drupal_parent_menu_item]['children'] != null) {
         mappedArr[mappedElem.drupal_parent_menu_item]['children'].push(mappedElem)
       }
       // If the element is at the root level, add it to first level elements array.

--- a/src/components/shared/navTabContent.js
+++ b/src/components/shared/navTabContent.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { setHeadingLevel } from 'utils/ug-utils';
 
 /* 
 Example Usage:
@@ -18,7 +17,6 @@ Example Usage:
 */
 
 function NavTabContent (props) {
-    let Heading = setHeadingLevel(props.headingLevel);
     let arialabel = `${props.id}-tab`;
     let classes = (props.active === true) ? `active show tab-pane fade`:`tab-pane fade`;
     if(props.classNames !== ``){

--- a/src/utils/ug-utils.js
+++ b/src/utils/ug-utils.js
@@ -63,8 +63,8 @@ function slugify(string) {
     .replace(/\s+/g, '-') // Replace spaces with -
     .replace(p, c => b.charAt(a.indexOf(c))) // Replace special characters
     .replace(/&/g, '-and-') // Replace & with 'and'
-    .replace(/[^\w\-]+/g, '') // Remove all non-word characters
-    .replace(/\-\-+/g, '-') // Replace multiple - with single -
+    .replace(/[^\w-]+/g, '') // Remove all non-word characters
+    .replace(/--+/g, '-') // Replace multiple - with single -
     .replace(/^-+/, '') // Trim - from start of text
     .replace(/-+$/, '') // Trim - from end of text
 }


### PR DESCRIPTION
# Summary of changes
Fix bug that results in a failed build when a disabled Drupal menu item has one or more enabled children.

## Frontend
- Add check for undefined and disabled parent in `headerMenu.js`

### Incidental Changes
- Remove unnecessary escape characters in `ug-utils.js` version of `slugify` function (fixes eslint warning)
- Remove unused variable and import from `navTabContent.js` (fixes eslint warning)

## Backend
N/A

# Test Plan

- Go to https://langmenu-chug.pantheonsite.io/
- Create or modify a menu so it has a disabled top-level link with one or more enabled child links
- Run a build on https://www.gatsbyjs.com/dashboard/2e86c058-a370-4898-ae51-9698cd178e8d/sites/e1480ab1-9d0f-4dcb-9fda-75347c74c1c9/deploys (or test locally)
- Verify the build completes successfully with no errors

