### PR TITLE
Remove duplicate id on testimonial slider

### DIFF
--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -82,7 +82,7 @@ function Testimonials (props) {
 				<div className="full-width-container bg-light">
 					<div className="container page-container">
 						<section className="row row-with-vspace site-content">
-							<div className="col-md-12 content-area" id="main-column">
+							<div className="col-md-12 content-area">
 								{testimonialHeading && <Heading className="carousel-header text-dark">{testimonialHeading}</Heading>}
 								<div className="testimonial-wrapper">
 									<SliderResponsive addToControlLabel="Testimonial">{testimonialUnits()}</SliderResponsive>


### PR DESCRIPTION
# Summary of changes
Removed duplicate id on testimonial slider (it has a main-column ID which already appears on the main container column).

## Frontend
- Removed duplicate id on testimonial slider (it has a main-column ID which already appears on the main container column).

## Backend
None

# Test Plan

Check any page with a testimonial slider using Siteimprove (e.g. Strategic Plan). Prior to the fix, you'll see a duplicate ID Level A error. After the fix, the error will have disappeared.

Fixed version: https://build-7aea34b3-c6f4-4745-b805-1fe4af13125c.gatsbyjs.io/strategic-plan/
