### PR TITLE
Automatically create responsive grid for sections containing only media/text widgets

### DIFF
--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -121,7 +121,14 @@ function SectionWidgets (props) {
         let onlyContainsMedia = primary.every(containsMediaTextOnly);
         let gridClasses = "";
         if(onlyContainsMedia){
-            let gridDivision = (primary.length % 4 === 0) ? "4" : "3";
+            // default is two items
+            let gridDivision = 2;
+
+            // if more than two items, allow for up to 3 or 4 columns
+            if (primary.length > 2){
+                gridDivision = (primary.length % 4 === 0) ? "4" : "3";
+            }
+
             gridClasses = `row-cols-1 row-cols-sm-2 row-cols-lg-${gridDivision}`;
         }
 

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -16,6 +16,11 @@ import StatsWidget from 'components/shared/statsWidget';
 import YamlWidget from 'components/shared/yamlWidget';
 import { ConditionalWrapper } from 'utils/ug-utils';
 
+// Check if section only contains media and text
+function containsMediaTextOnly (widget) {
+    return widget?.__typename === "paragraph__media_text";
+}
+
 // For the left column
 function renderPrimary(widget) {
     switch (widget?.__typename) {
@@ -100,8 +105,10 @@ function SectionWidgets (props) {
         let allWidgets = props.pageData;
         let sectionClasses = props.sectionClasses;
         
+        // sort all widgets into primary or secondary regions
         allWidgets.forEach(widgetData => {
             let secCol = widgetData.relationships?.field_section_column?.name;
+
             if (secCol === "right" || secCol === "Secondary") {
                 secondary.push(widgetData);
             } else {
@@ -109,6 +116,16 @@ function SectionWidgets (props) {
             }
         })
 
+        // if only media + text widgets in Primary
+        // then automatically create a grid (up to 3 or 4 columns)
+        let onlyContainsMedia = primary.every(containsMediaTextOnly);
+        let gridClasses = "";
+        if(onlyContainsMedia){
+            let gridDivision = (primary.length % 4 === 0) ? "4" : "3";
+            gridClasses = `row-cols-1 row-cols-sm-2 row-cols-lg-${gridDivision}`;
+        }
+
+        // if secondary region exists
         if (secondary.length > 0) {
             if (sectionClasses === "col-md-6") {
                 primaryClass = classNames("col-md-6 mb-5 mb-md-0");
@@ -118,12 +135,13 @@ function SectionWidgets (props) {
                 secondaryClass = classNames("col-md-3");
             }
         } else {
-            primaryClass = "row";
+            // only primary region exists
+            primaryClass = classNames('row', gridClasses);
         }
         
         return (<>
             <div className={primaryClass} data-title="Primary column">
-                <ConditionalWrapper condition={secondary.length > 0} wrapper={children => <div className="row">{children}</div>}>
+                <ConditionalWrapper condition={secondary.length > 0} wrapper={children => <div className={classNames('row', gridClasses)}>{children}</div>}>
                 {primary && primary.map(widget => {
                     return renderPrimary(widget)
                 })}                


### PR DESCRIPTION
# Summary of changes
If only media and text widgets exist in the Primary region of a a section, automatically create a grid from the contents.
Grid is stacked at XS, 2 columns at SM, and either 3 or 4 columns at LG (depending on number of items).

This fixes the responsiveness of pages like:
https://www.uoguelph.ca/study-in-canada/
https://www.uoguelph.ca/studentexperience/off-campus-living/

Note that on...
https://preview-ugconthub.gatsbyjs.io/lang/about-ug-lang/
The user would have to remove the general text widget from the section and instead use the section title field. At that point, the grid will kick in because the section only contains media + text widgets.

## Frontend
If only media and text widgets exist in the Primary region of a a section, automatically create a grid from the contents.

## Backend
None

# Test Plan

1. Run locally or view https://build-d5939eed-44fa-43a3-9a99-1226434a989c.gatsbyjs.io/
2. Check various pages and ensure nothing is broken.
3. The following page should still work: https://build-d5939eed-44fa-43a3-9a99-1226434a989c.gatsbyjs.io/media-and-text-examples/
4. The following pages should now respond appropriately:
   - https://build-d5939eed-44fa-43a3-9a99-1226434a989c.gatsbyjs.io/study-in-canada/
   - https://build-d5939eed-44fa-43a3-9a99-1226434a989c.gatsbyjs.io/studentexperience/off-campus-living/
5. This page will not respond with this feature because they've added a general text title at the top. If instead they were to use the Section title field, then the feature would kick in. But at least the page is no worse than it currently is: https://build-d5939eed-44fa-43a3-9a99-1226434a989c.gatsbyjs.io/lang/about-ug-lang/

