### PR TITLE
Update spacing and center text in Links Element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ config/aliases/*.yml
 config/sitemaps/*.yml
 # Auto-generated sitemaps
 config/sitemaps/
+
+# VSCode config
+.vscode/settings.json

--- a/src/components/shared/linksElement.js
+++ b/src/components/shared/linksElement.js
@@ -64,7 +64,7 @@ const LinksElement = (props) => {
         const levelHeading = setHeadingLevel(props.headingLinkLevel);
         const HeadingElement = (contentExists(props.text)) 
             ? <levelHeading className="linkswidget-heading">{props.headingLink}</levelHeading> 
-            : <span className={`${headingClass} ${levelHeading}`}>{props.headingLink}</span>;
+            : <span className={`${headingClass} ${levelHeading} text-center mt-4`}>{props.headingLink}</span>;
         const imageLinkClass = (contentExists(props.image))? "news-link": "";
         const linksContent = () => {
             if (contentExists(props.image)){


### PR DESCRIPTION
# Summary of changes
This was a request from Linda, she wanted the heading in the links element to have centered text and less spacing between the image and heading

## Frontend
- Added two classes to HeadingElement in linksElement.js

## Backend
N/A

# Test Plan

1. Go to https://ugconthub-linksspacing.gatsbyjs.io/healthy-campus and view the links element at the top of the page
1. Ensure the heading is centered and spaced correctly
1. Do the same for other pages that use the link element:
   https://ugconthub-linksspacing.gatsbyjs.io/studentexperience
   https://ugconthub-linksspacing.gatsbyjs.io/explore-all-programs


