### PR TITLE
Update home icon style in breadcrumbs

### DIFF
--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -96,7 +96,7 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                             <ol className="breadcrumb breadcrumb-right-tag">                                
                                 <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
                                     <a href={homeCrumbURL}>
-                                        <i aria-hidden="true" className="fa fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
+                                        <i aria-hidden="true" className="fa-sharp fa-light fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
                                     </a>
                                 </li>
                                 {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 


### PR DESCRIPTION
# Summary of changes
Linda asked me to make some changes to the breadcrumb styles, since most of those styles live in UofG-styles-dist.css, I've already made those changes seperately. All that remains on the Gatsby side is the home icon styles

## Frontend
- Added "fa-sharp fa-light" classes to icon in breadcrumb.js

## Backend
N/A

# Test Plan

1. View any page with breadcrumbs on it (ex. /president/presidential-installation/)
1. Ensure the home icon style looks like this https://fontawesome.com/icons/house?f=sharp&s=light

