### PR TITLE
Leftrightimage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -598,7 +598,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__media_text implements Node {
       drupal_id: String
       field_media_image_size: String
-      field_media_image_side: String
+      field_media_image_alignment: String
       field_media_text_desc: BodyField
       field_media_text_title: String
       relationships: paragraph__media_textRelationships

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -598,7 +598,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__media_text implements Node {
       drupal_id: String
       field_media_image_size: String
-      field_image_side: String
+      field_media_image_side: String
       field_media_text_desc: BodyField
       field_media_text_title: String
       relationships: paragraph__media_textRelationships

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -598,6 +598,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__media_text implements Node {
       drupal_id: String
       field_media_image_size: String
+      field_image_side: String
       field_media_text_desc: BodyField
       field_media_text_title: String
       relationships: paragraph__media_textRelationships

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,7 +20,9 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    
+    const imageLeft = props.widgetData?.field_image_side ?? 'left';
+    console.log(imageLeft);
+
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
     const videoURL = props.widgetData?.relationships.field_media_text_media?.field_media_oembed_video;
@@ -28,6 +30,7 @@ function MediaText (props) {
     const videoWidth = props.widgetData?.relationships.field_media_text_media?.field_video_width;
     const videoType = (videoURL?.includes("youtube") || videoURL?.includes("youtu.be") ? `youtube` : `vimeo`);
     const videoID = (videoType === `youtube` ? videoURL?.substr(videoURL?.length - 11) : videoURL?.substr(18));
+
     
     let mediaCol = "col-xs-12";
     let textCol = "col-xs-12";
@@ -202,30 +205,48 @@ function MediaText (props) {
     }
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
-    
+    if (videoURL || imageLeft === 'left'){
     return (
     <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
-        <div data-title="media" className={mediaCol}>
-            {videoURL &&
-            <Video videoID={videoID}
+    
+            {videoURL && <div data-title="media" className={mediaCol}>
+            <Video 
+                videoID={videoID}
                 videoTitle={videoTitle}
                 videoTranscript={videoTranscript}
                 videoType={videoType}
                 videoURL={videoURL}
                 videoHeight={videoHeight}
                 videoWidth={videoWidth}
-            />}
-
-            {imageURL && <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} />}
-        </div>
-        {textOrButtons &&
-        <div data-title="media-description" className={textCol}>
-            {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
-            {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
-            {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
-        </div>}
+            /> </div>}
+            
+            {imageURL && <div data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /></div>}
+      
+            {textOrButtons &&
+                <div data-title="media-description" className={textCol}>
+                    {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
+                    {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
+                    {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
+                </div>}
+       
     </ConditionalWrapper>
     );
+        } else {
+            return (
+            <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
+                {textOrButtons &&
+                    <div data-title="media-description" className={textCol}>
+                        {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
+                        {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
+                        {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
+                    </div>}
+        
+                {imageURL && <div className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
+            </ConditionalWrapper>
+            );
+        }
+
+
 }
 
 MediaText.propTypes = {
@@ -257,6 +278,7 @@ export const query = graphql`
   fragment MediaTextParagraphFragment on paragraph__media_text {
     drupal_id
     field_media_image_size
+    field_image_side
     field_media_text_title
     field_media_text_desc {
       processed

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,7 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    const imageLeft = props.widgetData?.field_image_side ?? 'left';
+    const imageLeft = props.widgetData?.field_image_side ?? 'Left';
     console.log(imageLeft);
 
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
@@ -205,7 +205,7 @@ function MediaText (props) {
     }
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
-    if (videoURL || imageLeft === 'left'){
+    if (videoURL || imageLeft !== 'Right'){
     return (
     <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
     

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,7 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    const imageLeft = props.widgetData?.field_media_image_alignment ?? 'Left';
+    const imageAlignment = props.widgetData?.field_media_image_alignment ?? 'Left';
 
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
@@ -204,8 +204,6 @@ function MediaText (props) {
     }
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
-    if (videoURL || imageLeft !== 'Right'){
-        return (
         <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
             <div data-title="media" className={mediaCol}>
                 {videoURL && 
@@ -230,22 +228,6 @@ function MediaText (props) {
                 </div>}
         
         </ConditionalWrapper>
-    );
-    } else {
-        return (
-        <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
-            {textOrButtons &&
-                <div data-title="media-description" className={textCol}>
-                    {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
-                    {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
-                    {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
-                </div>}
-    
-            {imageURL && <div  data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
-        </ConditionalWrapper>
-        );
-    }
-
 
 }
 
@@ -270,7 +252,7 @@ export const query = graphql`
     relationships {
       field_media_image {
         publicUrl
-        gatsbyImage(width: 1000, placeholder: BLURRED, layout: CONSTRAINED, formats: [AUTO, WEBP])
+        gatsbyImage(width: 1000, placeholder: BLURRED, layout: FULL_WIDTH, formats: [AUTO, WEBP])
       }
     }
   }

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,7 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    const imageLeft = props.widgetData?.field_media_image_side ?? 'Left';
+    const imageLeft = props.widgetData?.field_media_image_alignment ?? 'Left';
 
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
@@ -278,7 +278,7 @@ export const query = graphql`
   fragment MediaTextParagraphFragment on paragraph__media_text {
     drupal_id
     field_media_image_size
-    field_media_image_side
+    field_media_image_alignment
     field_media_text_title
     field_media_text_desc {
       processed

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,8 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    const imageLeft = props.widgetData?.field_image_side ?? 'Left';
-    console.log(imageLeft);
+    const imageLeft = props.widgetData?.field_media_image_side ?? 'Left';
 
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
@@ -206,45 +205,46 @@ function MediaText (props) {
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
     if (videoURL || imageLeft !== 'Right'){
-    return (
-    <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
-    
-            {videoURL && <div data-title="media" className={mediaCol}>
-            <Video 
-                videoID={videoID}
-                videoTitle={videoTitle}
-                videoTranscript={videoTranscript}
-                videoType={videoType}
-                videoURL={videoURL}
-                videoHeight={videoHeight}
-                videoWidth={videoWidth}
-            /> </div>}
-            
-            {imageURL && <div data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /></div>}
-      
+        return (
+        <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
+            <div data-title="media" className={mediaCol}>
+                {videoURL && 
+                    <Video 
+                        videoID={videoID}
+                        videoTitle={videoTitle}
+                        videoTranscript={videoTranscript}
+                        videoType={videoType}
+                        videoURL={videoURL}
+                        videoHeight={videoHeight}
+                        videoWidth={videoWidth}
+                    />}
+                
+                {imageURL && <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} />}
+            </div>
+
             {textOrButtons &&
                 <div data-title="media-description" className={textCol}>
                     {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
                     {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
                     {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
                 </div>}
-       
-    </ConditionalWrapper>
-    );
-        } else {
-            return (
-            <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
-                {textOrButtons &&
-                    <div data-title="media-description" className={textCol}>
-                        {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
-                        {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
-                        {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
-                    </div>}
         
-                {imageURL && <div  data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
-            </ConditionalWrapper>
-            );
-        }
+        </ConditionalWrapper>
+    );
+    } else {
+        return (
+        <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
+            {textOrButtons &&
+                <div data-title="media-description" className={textCol}>
+                    {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
+                    {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
+                    {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
+                </div>}
+    
+            {imageURL && <div  data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
+        </ConditionalWrapper>
+        );
+    }
 
 
 }
@@ -278,7 +278,7 @@ export const query = graphql`
   fragment MediaTextParagraphFragment on paragraph__media_text {
     drupal_id
     field_media_image_size
-    field_image_side
+    field_media_image_side
     field_media_text_title
     field_media_text_desc {
       processed

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -241,7 +241,7 @@ function MediaText (props) {
                         {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
                     </div>}
         
-                {imageURL && <div className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
+                {imageURL && <div  data-title="media" className={mediaCol}> <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} /> </div>}
             </ConditionalWrapper>
             );
         }


### PR DESCRIPTION
# Summary of changes
Added an option in Media Text Widget to display images on the right of the text block. Left the default (or no choice) to the image displayed on the left.

## Frontend
gatsby-node.js
 - added field_media_image_side to schema for paragraph__media_text type
 
mediaText.js
 - added field_media_image_side to the query.
 - added code to check if field_media_image_side data exists (default to 'Left' if does not) and assign it to a variable.
 - refactored code to check what side the image is to appear on and to render it either on the left or right.  Side choice will be ignored if a Video is the media item. 

## Backend
Multidev: https://imagealign-chug.pantheonsite.io/
**(Note: new mulitdev)**

In the Paragraph type: Media and Text added the field Image Side (Image only) - field_media_image_side. Defaults to Left for new items, but existing content with no value will still show on the left if is an image. Not a required field, so when updating existing pages users are not required to change it. But all new content will have a value. 

Help text : For images only: Choose the side of the text it will appear on. Note: this will only work when images are displayed beside the text. Also, if selected and content is stacked the image will appear below the text. 

Left - image on the left text on the right 
Right - text on the left and image on the right

# Test Plan

https://sstest.gatsbyjs.io/ is configured to build on this branch and usehttps://imagealign-chug.pantheonsite.io/ as the data source. When testing rebuild SS Test on gatsby cloud or on a local build.

Add a new page and add Media and Text widgets and select Left or Right, add a video to check if this setting is ignored. 
Check any existing page that has Media and Text widgets and ensure they are displaying as they should. 

https://sstest.gatsbyjs.io/learn/ shows how it will look with alternating left and right images. 

https://imagealign-chug.pantheonsite.io/node/876/edit?destination=/admin/content%3Ftitle%3Dlearn%26uid%3D%26type%3DAll%26status%3DAll%26field_tags_target_id_op%3Dor%26field_tags_target_id%3D%26items_per_page%3D50

[Widget Examples](https://sstest.gatsbyjs.io/widget-examples/) 
[Media and Text Examples](https://sstest.gatsbyjs.io/media-and-text-examples/)

Both work as expected (with some elements unchanged) note in the section with right columns - I have made the item to have the image on the right, to show that it works in this case).

I will be a way next week - feel free to make any changes need to approve this PR and publish it. Or make comments and I will deal with them when I get back.