### PR TITLE
Update media grid logic so it allows for single image

### DIFF
--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -120,7 +120,7 @@ function SectionWidgets (props) {
         // then automatically create a grid (up to 3 or 4 columns)
         let onlyContainsMedia = primary.every(containsMediaTextOnly);
         let gridClasses = "";
-        if(onlyContainsMedia){
+        if((onlyContainsMedia) && (primary.length > 1)){
             // default is two items
             let gridDivision = 2;
 


### PR DESCRIPTION
# Summary of changes
Update media grid logic so it allows for single image.

Fixes the issue where a single image in a Media Text widget in a primary region does not take up the full space. See the map on https://www.uoguelph.ca/grce/impact-report/ for an example.

![image](https://github.com/ccswbs/gus/assets/1927902/ebcfab5a-931a-4a5d-9106-a8c6b982e5b1)

## Frontend
Update media grid logic to only apply the grid logic if there's more than one image.

## Backend
None

# Test Plan

1. Check the deployed environment and confirm that the map is fixed: /grce/impact-report/
2. Confirm that the grid still responds as expected on /studentexperience

**NOTE:** You can ignore the missing styles from the styled-components. Styles are normally loaded from https://cdn.uoguelph.ca (which is basically another domain for our Azure production URL) however the style file that is generated does not live on our production server yet, so it won't be able to load them. (This will have no effect on production though. The styles will load at that point.) 

