### PR TITLE
Updated links widget columns and image size

### DIFF
--- a/src/components/shared/linksElement.js
+++ b/src/components/shared/linksElement.js
@@ -25,9 +25,9 @@ function setColumnClasses(numColumns) {
         case 3:
             return 'col-md-4 col-sm-6';
         case 4:
-            return 'col-md-3 col-sm-6';
+            return 'col-12 col-md-3 col-sm-6';
         default:
-            return 'col-md-3 col-sm-6';
+            return 'col-12 col-md-3 col-sm-6';
       }
 }
 function setElementClass(displayType) {

--- a/src/components/shared/linksItems.js
+++ b/src/components/shared/linksItems.js
@@ -114,8 +114,7 @@ fragment LinksWidgetParagraphFragment on paragraph__links_widget {
             relationships {
               field_media_image {
                 gatsbyImage(
-                  width: 400
-                  height: 300
+                  width: 1000
                   cropFocus: CENTER
                   formats: [AUTO, WEBP]
                 )


### PR DESCRIPTION
# Summary of changes
- added class for column size on mobile
- changed image size so it uses full width on mobile

## Frontend
- updated graphql query and return value for linkElement

## Backend
None

# Test Plan
1. Go to the /studentexperience page and switch to mobile view. The links items should resize correctly
2. The images associated with links items should span the width of the mobile view

