### PR TITLE
Addheading

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -641,6 +641,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       drupal_id: String
       field_section_classes: String
       field_section_title: String
+      field_heading_level: String
       relationships: paragraph__sectionRelationships
     }
     type paragraph__sectionRelationships implements Node {

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -180,6 +180,7 @@ export const query = graphql`
   fragment SectionParagraphFragment on paragraph__section {
     drupal_id
     field_section_title
+    field_heading_level
     field_section_classes
     relationships {
       field_section_content {

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -58,6 +58,7 @@ const WidgetSelector = ({widget}) => {
             : null;
         case "paragraph__section":
             let HeadingLevelSec = (widget.field_heading_level ? widget.field_heading_level : "h2");
+            if (HeadingLevelSec === "h5" || HeadingLevelSec === "h6") HeadingLevelSec = "h4";
             return (<>
               {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,10 +57,11 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
+            let sectionTitle = widget.pageData?.field_section_title;
             let HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(HeadingLevelSec)}
-              {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
+              {sectionTitle && <HeadingLevelSec id={slugify(sectionTitle)} className="mt-0">{sectionTitle}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -60,7 +60,7 @@ const WidgetSelector = ({widget}) => {
             const headingLevelSec = (widget.pageData?.field_heading_level ? widget.pageData.field_heading_level : "h2");
             return (<>
               {console.log(headingLevelSec)}
-              {widget.field_section_title && <h2 id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</h2>}
+              {widget.field_section_title && <headingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</headingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,7 +57,9 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
+            const headingLevelSec = (widget.pageData?.field_heading_level ? widget.pageData.field_heading_level : "h2");
             return (<>
+              {console.log(headingLevelSec)}
               {widget.field_section_title && <h2 id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</h2>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,10 +57,11 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
+            const sectionTitle = widget.pageData?.field_section_title;
             const HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(HeadingLevelSec)}
-              {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
+              {sectionTitle && <HeadingLevelSec id={slugify(sectionTitle)} className="mt-0">{sectionTitle}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,11 +57,10 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            let sectionTitle = widget.pageData?.field_section_title;
             let HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(HeadingLevelSec)}
-              {sectionTitle && <HeadingLevelSec id={slugify(sectionTitle)} className="mt-0">{sectionTitle}</HeadingLevelSec>}
+              {widget.pageData.field_section_title && <HeadingLevelSec id={slugify(widget.pageData.field_section_title)} className="mt-0">{widget.pageData.field_section_title}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,10 +57,10 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            const headingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
+            const HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
-              {console.log(headingLevelSec)}
-              {widget.field_section_title && <headingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</headingLevelSec>}
+              {console.log(HeadingLevelSec)}
+              {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,7 +57,7 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            const sectionTitle = widget.pageData?.field_section_title;
+            let sectionTitle = widget.pageData?.field_section_title;
             const HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(HeadingLevelSec)}

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,11 +57,10 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            let sectionTitle = widget.pageData?.field_section_title;
-            const HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
+            let HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(HeadingLevelSec)}
-              {sectionTitle && <HeadingLevelSec id={slugify(sectionTitle)} className="mt-0">{sectionTitle}</HeadingLevelSec>}
+              {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,10 +57,9 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            let HeadingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
+            let HeadingLevelSec = (widget.field_heading_level ? widget.field_heading_level : "h2");
             return (<>
-              {console.log(HeadingLevelSec)}
-              {widget.pageData.field_section_title && <HeadingLevelSec id={slugify(widget.pageData.field_section_title)} className="mt-0">{widget.pageData.field_section_title}</HeadingLevelSec>}
+              {widget.field_section_title && <HeadingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</HeadingLevelSec>}
                 <div key={widget.drupal_id} className="row" data-title="Section widget">
                     <SectionWidgets pageData={widget.relationships.field_section_content} sectionClasses={widget.field_section_classes} />
                 </div>

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -57,7 +57,7 @@ const WidgetSelector = ({widget}) => {
             transcript={video?.relationships?.field_media_file?.publicUrl} /> 
             : null;
         case "paragraph__section":
-            const headingLevelSec = (widget.pageData?.field_heading_level ? widget.pageData.field_heading_level : "h2");
+            const headingLevelSec = (widget.pageData?.field_section_title ? widget.pageData.field_section_title : "h2");
             return (<>
               {console.log(headingLevelSec)}
               {widget.field_section_title && <headingLevelSec id={slugify(widget.field_section_title)} className="mt-0">{widget.field_section_title}</headingLevelSec>}


### PR DESCRIPTION
# Summary of changes

Added an option in the Section Widget to change the heading level that will be displayed for the section title. Defaults to h2 if no choice is selected, and otherwise allows for headings to be used from h2-h6. 
## Frontend

gatsby-node.js

- added field_heading_level to the schema for paragraph__section type

sectionWidgets.js

- added field_heading_level to the query for paragraph__section type

widget.js

- added a variable to HeadingLevelSec that checks for and uses the heading level that was selected (defaults to h2 if none is selected) 
- Removed the line of code that defaulted the heading to h2 and replaced with a similar line that instead uses HeadingLevelSec to set the heading level of the section title

## Backend

Multidev: [https://secheading-chug.pantheonsite.io/](https://secheading-chug.pantheonsite.io/)

In the paragraph type: Section, added Heading Level - field_heading_level. Defaults to h2 for when a section is added but existing content will have the none option selected, and default to h2 through conditional logic in the widget.js file. Not required field so users don't need to change it when updating existing pages. 

Help text: This will be an h2 by default. Ensure you set it to h3 if it's a subsection of a region with its own h2 title. <strong>We strongly advise you refrain from choosing a level below h4</strong> so levels h5 and h6 are preserved for Accordion Item titles and their subsections. For AODA compliance, headings must be nested by their rank (or level). Headings with an equal or higher rank start a new section, headings with a lower rank start new subsections that are part of the higher ranked section. See the <strong><a href="https://www.w3.org/WAI/tutorials/page-structure/headings/">Web Accessibility Initiative page on Headings</a></strong> for more details.

The options available are fairly straightforward - Heading 2 is h2, Heading 3 is h3, etc.

# Test Plan

[https://mp-gus-test.netlify.app/](https://mp-gus-test.netlify.app/) is configured to build on this branch and use  [https://secheading-chug.pantheonsite.io/](https://secheading-chug.pantheonsite.io/) as the data source. When testing rebuild mp gus test on netlify or on a local build.

Add a new page and add Section widgets and select different heading levels, including the default or manually selecting none. Check any existing pages that have Section widgets and ensure they display as expected.

[https://mp-gus-test.netlify.app/heading-level-test/](https://mp-gus-test.netlify.app/heading-level-test/) is a test page which shows a section title in h2 and h4. 