### PR TITLE
Allow new YouTube embed URL pattern

### DIFF
--- a/src/components/shared/heroVideo.js
+++ b/src/components/shared/heroVideo.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import ReactPlayer from 'react-player';
 import PropTypes from 'prop-types';
-import { contentExists } from 'utils/ug-utils';
+import { extractVideoID, contentExists } from 'utils/ug-utils';
 import 'styles/heroVideo.css';
 
 class HeroVideo extends Component {
@@ -29,7 +29,7 @@ class HeroVideo extends Component {
         let videoWidth = this.props.videoWidth;
         let videoHeight = this.props.videoHeight;
         let videoType = (this.props.videoURL.includes("youtube") || this.props.videoURL.includes("youtu.be") ? `youtube` : `vimeo`);	
-        let videoID = (videoType === `youtube` ? this.props.videoURL.substr(this.props.videoURL.length - 11) : this.props.videoURL.substr(18));
+        let videoID = (videoType === `youtube` ? extractVideoID(this.props.videoURL) : this.props.videoURL.substring(18));
 
         let youtubeURL = "https://www.youtube.com/embed/";
         let vimeoURL = "https://player.vimeo.com/video/";	

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -5,7 +5,7 @@ import { graphql } from 'gatsby';
 import { GatsbyImage } from "gatsby-plugin-image";
 import SectionButtons from 'components/shared/sectionButtons';
 import Video from 'components/shared/video';
-import { ConditionalWrapper } from 'utils/ug-utils';
+import { extractVideoID, ConditionalWrapper } from 'utils/ug-utils';
 
 function MediaText (props) {
     
@@ -27,7 +27,7 @@ function MediaText (props) {
     const videoHeight = props.widgetData?.relationships.field_media_text_media?.field_video_height;
     const videoWidth = props.widgetData?.relationships.field_media_text_media?.field_video_width;
     const videoType = (videoURL?.includes("youtube") || videoURL?.includes("youtu.be") ? `youtube` : `vimeo`);
-    const videoID = (videoType === `youtube` ? videoURL?.substr(videoURL?.length - 11) : videoURL?.substr(18));
+    const videoID = (videoType === `youtube` ? extractVideoID(videoURL) : videoURL?.substring(18));
     
     let mediaCol = "col-xs-12";
     let textCol = "col-xs-12";

--- a/src/utils/ug-utils.js
+++ b/src/utils/ug-utils.js
@@ -79,12 +79,13 @@ function stripHTMLTags(content) {
 
 // Source: https://www.labnol.org/code/19797-regex-youtube-id
 function extractVideoID(url) {
-	var regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#]*).*/;
-	var match = url.match(regExp);
-	if (match && match[7].length === 11) {
-		return match[7];
-	} else {
-		alert('Could not extract video ID.');
+	let regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#]*).*/;
+	let match = url.match(regExp);
+
+	if (match) {
+		return match[7].split("?")[0];
+	} else{
+		console.log('Could not extract video ID.');
 	}
 }
 

--- a/src/utils/ug-utils.js
+++ b/src/utils/ug-utils.js
@@ -77,6 +77,16 @@ function stripHTMLTags(content) {
 	return content !== null ? content.replace(/(<([^>]+)>)/ig,"") : ``;
 }
 
+function extractVideoID(url) {
+	var regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#]*).*/;
+	var match = url.match(regExp);
+	if (match && match[7].length === 11) {
+		return match[7];
+	} else {
+		alert('Could not extract video ID.');
+	}
+}
+
 const ConditionalWrapper = ({ condition, wrapper, children }) => 
   condition ? wrapper(children) : children;
 
@@ -86,8 +96,9 @@ export {
 	fontAwesomeIconColour,
 	getNextHeadingLevel,
 	setHeadingLevel,
-    slugify,
+	slugify,
 	sortLastModifiedDates,
 	stripHTMLTags,
-    ConditionalWrapper
-   };
+	extractVideoID,
+	ConditionalWrapper
+};

--- a/src/utils/ug-utils.js
+++ b/src/utils/ug-utils.js
@@ -77,6 +77,7 @@ function stripHTMLTags(content) {
 	return content !== null ? content.replace(/(<([^>]+)>)/ig,"") : ``;
 }
 
+// Source: https://www.labnol.org/code/19797-regex-youtube-id
 function extractVideoID(url) {
 	var regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#]*).*/;
 	var match = url.match(regExp);


### PR DESCRIPTION
# Summary of changes
Fix issue where video URLs show "Video Unavailable" when we add YouTube videos.

Patterns that should work are...
- https://youtu.be/YIFSRE8SjtM?si=ARa347KgObNy3lAa. 
- https://www.youtube.com/watch?v=YIFSRE8SjtM
- https://youtu.be/Lj2O9OkBr3Q

## Frontend
Fix issue where video URLs show "Video Unavailable" when we add YouTube videos

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users:
- On [Media page](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup/SitePages/Media.aspx), we can specify that users can use the new embed code as well.

## Backend
None

# Test Plan

Check the Netlify build and ensure that...
1. All videos show on Program pages: /programs/bachelor-of-applied-science-basc/
2. All videos show on /media-and-text-examples/
3. If you know of other videos, check that they are working.