### PR TITLE
Add id to media text headings

### DIFF
--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -5,7 +5,7 @@ import { graphql } from 'gatsby';
 import { GatsbyImage } from "gatsby-plugin-image";
 import SectionButtons from 'components/shared/sectionButtons';
 import Video from 'components/shared/video';
-import { ConditionalWrapper } from 'utils/ug-utils';
+import { slugify, ConditionalWrapper } from 'utils/ug-utils';
 
 function MediaText (props) {
     
@@ -220,7 +220,7 @@ function MediaText (props) {
         </div>
         {textOrButtons &&
         <div data-title="media-description" className={textCol}>
-            {mediaTitle && <h3 {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
+            {mediaTitle && <h3 id={slugify(mediaTitle)} {...(headingClass !== `` ? {className:headingClass} : {})}>{mediaTitle}</h3>}
             {mediaDescription && <div {...(textColBg === `bg-dark` ? {className:`text-light`} : {})} dangerouslySetInnerHTML={{ __html: mediaDescription}} />}
             {mediaButtons && <SectionButtons key={props.widgetData.relationships.field_button_section.drupal_id} pageData={props.widgetData.relationships.field_button_section} />}
         </div>}


### PR DESCRIPTION
# Summary of changes
Add id to media text headings so users can link to a media heading as part of their anchor links.

## Frontend
Add id to media text headings so users can link to a media heading as part of their anchor links.

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Check a media and text widget
2. See if there is an id on it