### PR TITLE
Increase timeout to 60000 for wordpress query

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -96,6 +96,7 @@ module.exports = {
           perPage: 20,
           requestConcurrency: 2,
           previewRequestConcurrency: 2,
+          timeout: 60000,
         },
         develop: {
           //caches media files outside of Gatsby's default cache an thus allows them to persist through a cache reset.


### PR DESCRIPTION
# Summary of changes
Increase timeout to 60000 for wordpress query

## Frontend
None

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

See if build completes