### PR TITLE
Update Notes logic and heading margin

### DIFF
--- a/src/components/shared/courses.js
+++ b/src/components/shared/courses.js
@@ -8,8 +8,8 @@ function Courses ({ courseData, courseNotes, headingLevel }) {
 	var courseList="";
 	var trackCourseLevel="";
 	var coursesDisplay="<section class='row row-with-vspace'>";
-	var columnSetting = ((courseNotes === null || courseNotes === "") || (courseData === null || courseData === undefined || courseData.length === 0)) ? "col-lg-12" : "col-lg-6";
 	var columnSetting = (!courseNotes || !courseData || !courseData.length) ? "col-lg-12" : "col-lg-6";
+	
 	courseData.sort((a,b) => (a.field_level > b.field_level) ? 1 : (a.field_level === b.field_level) ? ((a.field_code > b.field_code) ? 1 : -1) : -1);
 
 	if ((courseData !== null) && (courseData !== undefined)) {

--- a/src/components/shared/courses.js
+++ b/src/components/shared/courses.js
@@ -9,7 +9,7 @@ function Courses ({ courseData, courseNotes, headingLevel }) {
 	var trackCourseLevel="";
 	var coursesDisplay="<section class='row row-with-vspace'>";
 	var columnSetting = ((courseNotes === null || courseNotes === "") || (courseData === null || courseData === undefined || courseData.length === 0)) ? "col-lg-12" : "col-lg-6";
-	
+	var columnSetting = (!courseNotes || !courseData || !courseData.length) ? "col-lg-12" : "col-lg-6";
 	courseData.sort((a,b) => (a.field_level > b.field_level) ? 1 : (a.field_level === b.field_level) ? ((a.field_code > b.field_code) ? 1 : -1) : -1);
 
 	if ((courseData !== null) && (courseData !== undefined)) {

--- a/src/components/shared/courses.js
+++ b/src/components/shared/courses.js
@@ -8,10 +8,10 @@ function Courses ({ courseData, courseNotes, headingLevel }) {
 	var courseList="";
 	var trackCourseLevel="";
 	var coursesDisplay="<section class='row row-with-vspace'>";
-	var columnSetting = ((courseNotes === null || courseNotes === "") || (courseData === null || courseData === undefined)) ? "col-lg-12" : "col-lg-6";
+	var columnSetting = ((courseNotes === null || courseNotes === "") || (courseData === null || courseData === undefined || courseData.length === 0)) ? "col-lg-12" : "col-lg-6";
 	
 	courseData.sort((a,b) => (a.field_level > b.field_level) ? 1 : (a.field_level === b.field_level) ? ((a.field_code > b.field_code) ? 1 : -1) : -1);
-	
+
 	if ((courseData !== null) && (courseData !== undefined)) {
 		courseData.forEach(course => {
 			let courseTitle = course.title;
@@ -39,7 +39,7 @@ function Courses ({ courseData, courseNotes, headingLevel }) {
 	}
 
 	if ((courseNotes !== null) && (courseNotes !== "")) {
-		coursesDisplay += "<div class='" + columnSetting + "'><" + headingLevel + " class='course-notes-heading'>Notes</" + headingLevel + ">" + courseNotes + "</div>";
+		coursesDisplay += "<div class='" + columnSetting + "'><" + headingLevel + " class='course-notes-heading mt-2'>Notes</" + headingLevel + ">" + courseNotes + "</div>";
 	}
 
 	coursesDisplay += "</section>";


### PR DESCRIPTION
# Summary of changes
Update Notes logic and heading margin

## Frontend
- Update Notes logic to display notes in 12 columns when there is no course data (it was supposed to do this before, but it was not checking to see if the array was empty, only if the array was undefined or null)
- Update Notes heading (h4) to have a top margin of mt-2

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[Not applicable] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.


### Notes Logic Update
**Before:**
<img width="1425" alt="image" src="https://github.com/ccswbs/gus/assets/1927902/dcc3a188-b7ae-4c03-aef2-b21cc1a307b8">

**After:**
<img width="1438" alt="image" src="https://github.com/ccswbs/gus/assets/1927902/1b0736df-a068-49cc-93c7-f680b6d59eff">

### Notes Heading Update
**Before:**
<img width="1440" alt="image" src="https://github.com/ccswbs/gus/assets/1927902/875ca57d-0b9c-40eb-8912-9ad70fdd1033">

**After:**
<img width="1451" alt="image" src="https://github.com/ccswbs/gus/assets/1927902/47403bb9-829f-4663-a95d-cad4be4a8a90">


## Backend
None

# Test Plan

1. Open the Gatsby Cloud or Netlify build: https://deploy-preview-169--ugconthub.netlify.app
2. Visit https://deploy-preview-169--ugconthub.netlify.app/programs/bachelor-of-science/ and ensure the notes take up the full 12 columns
3. Visit https://deploy-preview-169--ugconthub.netlify.app/programs/bachelor-of-creative-arts-health-and-wellness/ and ensure the course data appears as expected (full 12 columns)
4. Visit https://deploy-preview-169--ugconthub.netlify.app/programs/bachelor-of-arts-ba/ and ensure both notes and course data appear AND notes margin is set to mt-2 (i.e., in line with the table)