### PR TITLE
Media Alignment for text and media on the same row

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -598,6 +598,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type paragraph__media_text implements Node {
       drupal_id: String
       field_media_image_size: String
+      field_media_alignment: String
       field_media_text_desc: BodyField
       field_media_text_title: String
       relationships: paragraph__media_textRelationships

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -205,7 +205,7 @@ function MediaText (props) {
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
 
     if (mediaAlignment !== "left") {
-        wrapperCol = wrapperCol + " flex-row-reverse"
+        wrapperCol = classNames(wrapperCol, "flex-row-reverse");
     };
 
     return (

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,7 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
-    const imageAlignment = props.widgetData?.field_media_alignment ?? 'left';
+    const mediaAlignment = props.widgetData?.field_media_alignment ?? 'left';
     
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -204,7 +204,7 @@ function MediaText (props) {
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
 
-    if (imageAlignment !== "left") {
+    if (mediaAlignment !== "left") {
         wrapperCol = wrapperCol + " flex-row-reverse"
     };
 

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -20,6 +20,7 @@ function MediaText (props) {
     const imageURL = mediaRelationships?.field_media_image;	
     const imageAlt = props.widgetData?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.widgetData?.field_media_image_size;
+    const imageAlignment = props.widgetData?.field_media_alignment ?? 'left';
     
     const videoTitle = props.widgetData?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
@@ -202,7 +203,11 @@ function MediaText (props) {
     }
     headingClass = classNames(headingClass, headingColor);
     textCol = classNames(textCol, textColBg, textColHeight, textColPadding, "text-break");
-    
+
+    if (imageAlignment !== "left") {
+        wrapperCol = wrapperCol + " flex-row-reverse"
+    };
+
     return (
     <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
         <div data-title="media" className={mediaCol}>
@@ -249,7 +254,7 @@ export const query = graphql`
     relationships {
       field_media_image {
         publicUrl
-        gatsbyImage(width: 1000, placeholder: BLURRED, layout: CONSTRAINED, formats: [AUTO, WEBP])
+        gatsbyImage(width: 1000, placeholder: BLURRED, layout: FULL_WIDTH, formats: [AUTO, WEBP])
       }
     }
   }
@@ -257,6 +262,7 @@ export const query = graphql`
   fragment MediaTextParagraphFragment on paragraph__media_text {
     drupal_id
     field_media_image_size
+    field_media_alignment
     field_media_text_title
     field_media_text_desc {
       processed


### PR DESCRIPTION
Summary of changes
Note: this replaces PR #153 - will leave it for comments 

Added an option in Media Text Widget to display images on the right of the text block. Left the default (or no choice) to the image displayed on the left.

Frontend
gatsby-node.js

added field_media_alignment to schema for paragraph__media_text type
mediaText.js

added field_media_alignment to the query.
added code to check if field_media_alignment  data exists (default to 'Left' if does not) and assign it to a variable.
refactored code to check what side the image is to appear on and to render it either on the left or right. Alignment choice will if media and text are not in a row.
Backend
Multidev: https://imagealign-chug.pantheonsite.io/

In the Paragraph type: Media and Text added the field Media Alignment - field_media_alignment. Defaults to Left for new items, but existing content with no value will still show on the left if is an image. Not a required field, so when updating existing pages users are not required to change it. But all new content will have a value.

Help text :
 Note: This setting is only when the media (text or video) is displayed beside the text. If other settings place the media above the text this value will be ignored. 

**Left** will place the media to the left of the text.<br>
**Right** will place the media to the right of the text.<br>

Default is Left, on small screens the media will be above the text.

Test Plan
https://sstest.gatsbyjs.io/ is configured to build on this branch and usehttps://imagealign-chug.pantheonsite.io/ as the data source. When testing rebuild SS Test on gatsby cloud or on a local build.

Add a new page and add Media and Text widgets and select Left or Right, add a video to check if this setting is ignored.
Check any existing page that has Media and Text widgets and ensure they are displaying as they should.

https://sstest.gatsbyjs.io/learn/ shows how it will look with alternating left and right images.

https://imagealign-chug.pantheonsite.io/node/876/edit?destination=/admin/content%3Ftitle%3Dlearn%26uid%3D%26type%3DAll%26status%3DAll%26field_tags_target_id_op%3Dor%26field_tags_target_id%3D%26items_per_page%3D50

[Widget Examples](https://sstest.gatsbyjs.io/widget-examples/)
[Media and Text Examples](https://sstest.gatsbyjs.io/media-and-text-examples/)

Both work as expected (with some elements unchanged) note in the section with right columns - I have made the item to have the image on the right, to show that it works in this case).