### PR TITLE
change twitter icon to xtwitter icon

### DIFF
--- a/src/components/blocks/ovc/footerSocial.js
+++ b/src/components/blocks/ovc/footerSocial.js
@@ -5,10 +5,10 @@ import 'styles/ovc/social-icons.css';
 import {
   FaInstagram,
   FaFacebookSquare,
-  FaTwitterSquare,
   FaLinkedin,
   FaYoutubeSquare
 } from "react-icons/fa";
+import { FaSquareXTwitter } from "react-icons/fa6";
 
 const FooterSocial = () => (
   <div>
@@ -27,7 +27,7 @@ const FooterSocial = () => (
     </a>
     <a href="https://twitter.com/OntVetCollege/" className="text-dark-social">
       <span className="visually-hidden">Connect with OVC on Twitter</span>
-      <FaTwitterSquare style={{fontSize: "4.8rem"}} />
+      <FaSquareXTwitter style={{fontSize: "4.8rem"}} />
     </a>
     <a href="https://www.youtube.com/user/OntarioVetCollege" className="text-dark-social">
       <span className="visually-hidden">Connect with OVC on YouTube</span>


### PR DESCRIPTION
# Summary of changes
Change the footer icon for twitter from the bird to the X. In the OVC custom footer. 

## Frontend
in srs/components/blocks/ovc/footerSocial.js removed the old twitter icon import and added FaSquareXTwitter import from fa6 react Icons

[X] My changes are accessible (at minimum WCAG 2.0 Level AA)
[X] My changes are responsive and appear as expected on mobile and desktop views.
[N/A] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
No changes 

# Test Plan

Build locally - with the live site backend (https://api.liveugconthub.uoguelph.dev/) check any OVC page for the new X twitter logo in the footer

alsohttps://deploy-preview-177--ugconthub.netlify.app/ was built with this branch using the live site. 

a random page - https://deploy-preview-177--ugconthub.netlify.app/neuroscience-research/ should have the correct icon in the footer.