### PR TITLE
Set heading class to h4 for linkswidget grid

### DIFF
--- a/src/components/shared/linksElement.js
+++ b/src/components/shared/linksElement.js
@@ -64,7 +64,7 @@ const LinksElement = (props) => {
         const levelHeading = setHeadingLevel(props.headingLinkLevel);
         const HeadingElement = (contentExists(props.text)) 
             ? <levelHeading className="linkswidget-heading">{props.headingLink}</levelHeading> 
-            : <span className={`${headingClass} ${levelHeading} text-center mt-4`}>{props.headingLink}</span>;
+            : <span className={`${headingClass} h4 text-center mt-4`}>{props.headingLink}</span>;
         const imageLinkClass = (contentExists(props.image))? "news-link": "";
         const linksContent = () => {
             if (contentExists(props.image)){
@@ -138,7 +138,7 @@ LinksElement.propTypes = {
     children: ``,
     extraClasses: ``,
     headingLink: ``,
-    headingLinkLevel: 'h2',
+    headingLinkLevel: 'h3',
     image: null,
     numColumns: 4,
     tag: 'ul',

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -27,11 +27,11 @@ const NotFoundPage = () => {
               </li>
 
               <li>
-                The search engine has an out-of-date listing for this page - <a href="mailto:websites@uoguelph.ca">please let us know!</a>
+                The search engine has an out-of-date listing for this page - <a href="mailto:ithelp@uoguelph.ca">please let us know!</a>
               </li>
 
               <li>
-                The university has removed this page (either on purpose or by mistake) - <a href="mailto:websites@uoguelph.ca">please let us know!</a>
+                The university has removed this page (either on purpose or by mistake) - <a href="mailto:ithelp@uoguelph.ca">please let us know!</a>
               </li>
             </ol>
 


### PR DESCRIPTION
# Summary of changes
Set heading on links widget to appear as an h4

## Frontend
Set heading on links widget to appear as an h4

Broken
![image](https://github.com/ccswbs/gus/assets/1927902/8456420c-4158-4338-b84a-9d48e81e3c9c)

Fixed
![image (1)](https://github.com/ccswbs/gus/assets/1927902/8808c502-5d03-4b58-8572-116ce8a9e000)


[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

- View https://deploy-preview-183--ugconthub.netlify.app/explore-all-programs/
- Confirm the headings appear as h4s instead of h2s