### PR TITLE
Use the PublishPipelineArtifact task (as recommended by Azure DevOps) on pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,8 +97,8 @@ steps:
     archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
     replaceExistingArchive: true
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifacts@1
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'drop'
-    publishLocation: 'Container'
+    targetPath: '$(Pipeline.Workspace)'
+    artifact: 'drop'
+    publishLocation: 'pipeline'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ steps:
     archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
     replaceExistingArchive: true
 
-- task: PublishPipelineArtifacts@1
+- task: PublishPipelineArtifact@1
   inputs:
     targetPath: '$(Pipeline.Workspace)'
     artifact: 'drop'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,6 +99,6 @@ steps:
 
 - task: PublishPipelineArtifact@1
   inputs:
-    targetPath: '$(Pipeline.Workspace)'
+    targetPath: '$(Build.ArtifactStagingDirectory)'
     artifact: 'drop'
     publishLocation: 'pipeline'


### PR DESCRIPTION
# Summary of changes
Azure DevOps [recommends](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-build-artifacts-v1?view=azure-pipelines) switching from the [PublishBuildArtifacts@1](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-build-artifacts-v1?view=azure-pipelines) task to the [PublishPipelineArtifact@1](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-pipeline-artifact-v1?view=azure-pipelines) for faster performance.

## Frontend
None

## Backend
None

# Test Plan

1. Run pipeline (since it's a PR affecting the pipeline, it will take an hour, so I ran it over lunch): https://dev.azure.com/uoguelph/CCS/_build/results?buildId=16513&view=results
2. Confirm nothing has changed in how the artifact is created on the pipeline (you should see 1 published artifact on the pipeline result called "drop" with the expected build zip file inside) [Confirmed]

![image](https://github.com/ccswbs/gus/assets/1927902/61bc8613-6278-484d-b0eb-8e9628ef99c6)

![image](https://github.com/ccswbs/gus/assets/1927902/7f473a24-176b-4e8b-a93a-ccfdd3f2ce65)
