### PR TITLE
Add ability to link to tabs

### DIFF
--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -14,20 +14,25 @@ const PageTabs = (props) => {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    const title = params.get("tab")
-    let tabID = tabs[0]?.drupal_id ?? ""
+    const titleOrID = params.get("tab")
 
-    if (title) {
-      for (const tab of tabs) {
-        if (title === slugify(tab.field_tab_title.toLowerCase())) {
-          tabID = tab.drupal_id
-          container.current?.scrollIntoView({ block: "start", inline: "nearest" })
-          break
-        }
-      }
+    if (titleOrID) {
+      // Try to find a tab with a matching drupal id
+      let found = tabs.find((tab) => tab.drupal_id === titleOrID)
+
+      // If we couldn't find a matching id, then try and find a matching title
+      found ??= tabs.find((tab) => titleOrID === slugify(tab.field_tab_title.toLowerCase()))
+
+      // Set the active tab to which ever was found
+      // If neither could be found then set the active tab to the first tab.
+      setActiveTab(found?.drupal_id ?? tabs[0]?.drupal_id)
+
+      // Make sure the tab is visible
+      container.current?.scrollIntoView({ block: "start", inline: "nearest" })
+    } else {
+      // No param passed in the url so default to showing the first tab.
+      setActiveTab(tabs[0]?.drupal_id)
     }
-
-    setActiveTab(tabID)
   }, [])
 
   if (tabs.length <= 0) {

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -15,7 +15,7 @@ const PageTabs = (props) => {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const title = params.get("tab")
-    let tabID = tabs[0]?.drupal_id
+    let tabID = tabs[0]?.drupal_id ?? ""
 
     if (title) {
       for (const tab of tabs) {

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -1,29 +1,44 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import Tab from "react-bootstrap/Tab"
 import Tabs from "react-bootstrap/Tabs"
-import Fade from 'react-bootstrap/Fade';
-import 'styles/pageTabs.css';
+import Fade from "react-bootstrap/Fade"
+import "styles/pageTabs.css"
+import { slugify } from "../../utils/ug-utils"
 
 const PageTabs = (props) => {
+  const container = useRef(null)
   const tabs = props.pageData?.relationships?.field_tabs ?? []
   const [activeTab, setActiveTab] = useState("")
 
   useEffect(() => {
-    let initialTab = tabs[0]?.drupal_id;
-    setActiveTab(initialTab)
+    const params = new URLSearchParams(window.location.search)
+    const title = params.get("tab")
+    let tabID = tabs[0]?.drupal_id
+
+    if (title) {
+      for (const tab of tabs) {
+        if (title === slugify(tab.field_tab_title.toLowerCase())) {
+          tabID = tab.drupal_id
+          container.current?.scrollIntoView({ block: "start", inline: "nearest" })
+          break
+        }
+      }
+    }
+
+    setActiveTab(tabID)
   }, [])
-  
+
   if (tabs.length <= 0) {
     return null
   }
 
   return (
-    <div className="col-md-12 content-area nav-tabs-container">
+    <div className="col-md-12 content-area nav-tabs-container" ref={container}>
       <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify transition={Fade}>
         {tabs.map((tab) => (
-          <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title}>
+          <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title.toUpperCase()}>
             <div dangerouslySetInnerHTML={{ __html: tab.field_tab_body.processed }} />
           </Tab>
         ))}

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -10,7 +10,7 @@ import { slugify } from "../../utils/ug-utils"
 const PageTabs = (props) => {
   const container = useRef(null)
   const tabs = props.pageData?.relationships?.field_tabs ?? []
-  const [activeTab, setActiveTab] = useState("")
+  const [activeTab, setActiveTab] = useState(tabs[0]?.drupal_id ?? "")
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -28,9 +28,6 @@ const PageTabs = (props) => {
       setActiveTab(found?.drupal_id ?? tabs[0]?.drupal_id)
 
       found && container.current?.scrollIntoView({ block: "start", inline: "nearest" })
-    } else {
-      // No param passed in the url so default to showing the first tab.
-      setActiveTab(tabs[0]?.drupal_id)
     }
   }, [])
 

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -1,93 +1,60 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { graphql } from 'gatsby';
-import { contentExists } from 'utils/ug-utils.js';
-import NavTabs from 'components/shared/navTabs';
-import NavTabHeading from 'components/shared/navTabHeading';
-import NavTabContent from 'components/shared/navTabContent';
+import React, { useState, useEffect } from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
+import Tab from "react-bootstrap/Tab"
+import Tabs from "react-bootstrap/Tabs"
+import 'styles/pageTabs.css';
 
-function renderTabInfo (pageData) {
-    
-    let activeValue = true;
-    let navTabHeadings = [];
-    let navTabContent = [];    
+const PageTabs = (props) => {
+  const tabs = props.pageData?.relationships?.field_tabs ?? []
+  const [activeTab, setActiveTab] = useState("")
 
-    if (contentExists(pageData)) {
+  useEffect(() => {
+    let initialTab = tabs[0]?.drupal_id;
+    setActiveTab(initialTab)
+  }, [])
+  
+  if (tabs.length <= 0) {
+    return null
+  }
 
-        let tabID = "";
-
-        for (let i = 0; i < pageData.relationships.field_tabs.length; i++) {
-            tabID = "pills-" + pageData.relationships.field_tabs[i].drupal_id;
-
-            if (i > 0) activeValue = false;
-
-            navTabHeadings.push(<NavTabHeading key={`navTabHeading-` + i}
-                active={activeValue}
-                heading={pageData.relationships.field_tabs[i].field_tab_title}
-                controls={tabID}
-            />);
-
-            navTabContent.push(<NavTabContent key={`navTabContent-` + i}
-                active={activeValue}
-                id={tabID}
-                content={<div dangerouslySetInnerHTML={{ __html: pageData.relationships.field_tabs[i].field_tab_body.processed }} />}
-            />);
-        }
-        return (
-        <React.Fragment>
-            <NavTabs headings={
-                navTabHeadings.map((heading) => {
-                    return heading;
-                    })
-                }>
-                {navTabContent.map((content) => {
-                    return content;
-
-                })}
-            </NavTabs>
-        </React.Fragment>
-        )
-    }
-    return null;
+  return (
+    <div className="col-md-12 content-area">
+      <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify>
+        {tabs.map((tab) => (
+          <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title}>
+            <div dangerouslySetInnerHTML={{ __html: tab.field_tab_body.processed }} />
+          </Tab>
+        ))}
+      </Tabs>
+    </div>
+  )
 }
 
-function pageTabs (props) {
-
-    if (contentExists(props.pageData) && props.pageData.length !== 0) {        
-        return (
-            <div className="col-md-12 content-area">
-                {renderTabInfo(props.pageData)}
-           </div>
-        )
-    } else {
-        return null;
-    }
+PageTabs.propTypes = {
+  pageData: PropTypes.object,
 }
 
-pageTabs.propTypes = {
-    pageData: PropTypes.object,
+PageTabs.defaultProps = {
+  pageData: ``,
 }
 
-pageTabs.defaultProps = {
-    pageData: ``,
-}
-
-export default pageTabs
+export default PageTabs
 
 export const query = graphql`
-    fragment SectionTabsParagraphFragment on paragraph__section_tabs {
+  fragment SectionTabsParagraphFragment on paragraph__section_tabs {
+    drupal_id
+    relationships {
+      field_tabs {
         drupal_id
-        relationships {
-          field_tabs {
-            drupal_id
-            field_tab_title
-            field_tab_body {
-              processed
-            }
-          }
-          field_section_column {
-            name
-          }
+        field_tab_title
+        field_tab_body {
+          processed
         }
+      }
+      field_section_column {
+        name
+      }
     }
+  }
 `

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -27,8 +27,7 @@ const PageTabs = (props) => {
       // If neither could be found then set the active tab to the first tab.
       setActiveTab(found?.drupal_id ?? tabs[0]?.drupal_id)
 
-      // Make sure the tab is visible
-      container.current?.scrollIntoView({ block: "start", inline: "nearest" })
+      found && container.current?.scrollIntoView({ block: "start", inline: "nearest" })
     } else {
       // No param passed in the url so default to showing the first tab.
       setActiveTab(tabs[0]?.drupal_id)
@@ -44,7 +43,7 @@ const PageTabs = (props) => {
       <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify transition={Fade}>
         {tabs.map((tab) => (
           <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title.toUpperCase()}>
-            <div dangerouslySetInnerHTML={{ __html: tab.field_tab_body.processed }} />
+            <div data-tab-id={tab.drupal_id} dangerouslySetInnerHTML={{ __html: tab.field_tab_body.processed }} />
           </Tab>
         ))}
       </Tabs>

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import Tab from "react-bootstrap/Tab"
 import Tabs from "react-bootstrap/Tabs"
+import Fade from 'react-bootstrap/Fade';
 import 'styles/pageTabs.css';
 
 const PageTabs = (props) => {
@@ -19,8 +20,8 @@ const PageTabs = (props) => {
   }
 
   return (
-    <div className="col-md-12 content-area">
-      <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify>
+    <div className="col-md-12 content-area nav-tabs-container">
+      <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify transition={Fade}>
         {tabs.map((tab) => (
           <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title}>
             <div dangerouslySetInnerHTML={{ __html: tab.field_tab_body.processed }} />

--- a/src/styles/pageTabs.css
+++ b/src/styles/pageTabs.css
@@ -1,20 +1,19 @@
-
-ul.nav-tabs {
+#content #main-column .container.page-container .nav-tabs-container ul.nav-tabs {
   display: flex;
-  border-bottom: 0.5rem solid #FFC72A !important;
+  border-bottom: 0.5rem solid #ffc72a !important;
   padding: 0 !important;
   gap: 0.5rem;
 }
 
-ul.nav-tabs li.nav-item {
+#content #main-column .container.page-container .nav-tabs-container ul.nav-tabs li.nav-item {
   margin-bottom: 0;
 }
 
-ul.nav-tabs li.nav-item::before {
+#content #main-column .container.page-container .nav-tabs-container ul.nav-tabs li.nav-item::before {
   content: none;
 }
 
-.nav-tabs .nav-link {
+#content #main-column .container.page-container .nav-tabs-container .nav-tabs .nav-link {
   color: #000;
   font-weight: 700;
   background-color: #eee;
@@ -24,22 +23,18 @@ ul.nav-tabs li.nav-item::before {
   border-bottom: 0.5rem solid #fff !important;
 }
 
-.nav-tabs .nav-link:hover,
-.nav-tabs .nav-link:focus {
+#content #main-column .container.page-container .nav-tabs-container .nav-tabs .nav-link:hover,
+#content #main-column .container.page-container .nav-tabs-container .nav-tabs .nav-link:focus {
   background-color: #ddd;
 }
 
-.nav-tabs .nav-link.active {
+#content #main-column .container.page-container .nav-tabs-container .nav-tabs .nav-link.active {
   color: #000;
   font-weight: 700;
-  background-color: #FFC72A;
-  border-bottom: 0.5rem solid #FFC72A !important;
+  background-color: #ffc72a;
+  border-bottom: 0.5rem solid #ffc72a !important;
 }
 
-.nav-tabs-container .tab-content .tab-pane {
+#content #main-column .container.page-container .nav-tabs-container .tab-content .tab-pane {
   transition-duration: 250ms;
-}
-
-.tab-content {
-  padding: 2rem 0;
 }

--- a/src/styles/pageTabs.css
+++ b/src/styles/pageTabs.css
@@ -1,0 +1,41 @@
+
+ul.nav-tabs {
+  display: flex;
+  border-bottom: 0.5rem solid #FFC72A !important;
+  padding: 0 !important;
+  gap: 0.5rem;
+}
+
+ul.nav-tabs li.nav-item {
+  margin-bottom: 0;
+}
+
+ul.nav-tabs li.nav-item::before {
+  content: none;
+}
+
+.nav-tabs .nav-link {
+  color: #000;
+  font-weight: 700;
+  background-color: #eee;
+  border-radius: 0.25rem 0.25rem 0 0;
+  margin: 0;
+  padding: 1.25rem;
+  border-bottom: 0.5rem solid #fff !important;
+}
+
+.nav-tabs .nav-link:hover,
+.nav-tabs .nav-link:focus {
+  background-color: #ddd;
+}
+
+.nav-tabs .nav-link.active {
+  color: #000;
+  font-weight: 700;
+  background-color: #FFC72A;
+  border-bottom: 0.5rem solid #FFC72A !important;
+}
+
+.tab-content {
+  padding: 2rem 0;
+}

--- a/src/styles/pageTabs.css
+++ b/src/styles/pageTabs.css
@@ -36,6 +36,10 @@ ul.nav-tabs li.nav-item::before {
   border-bottom: 0.5rem solid #FFC72A !important;
 }
 
+.nav-tabs-container .tab-content .tab-pane {
+  transition-duration: 250ms;
+}
+
 .tab-content {
   padding: 2rem 0;
 }


### PR DESCRIPTION
# Summary of changes
Added the ability to link to a page and have a specified tab open.

## Frontend

- Refactored pageTabs.js to use react-bootstrap
- Add link logic to pageTabs.js
- Added pageTabs.css to fix styles for react-bootstrap version of tabs

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

Insert steps. Include URLs of Netlify test site and Drupal multidev.

1. Go to any page using the tabs widget (ex. https://deploy-preview-190--ugconthub.netlify.app/admission/undergraduate/requirements/canadian-transfer-students)
2. Ensure the tabs function correctly.
3. Go to the same page but modify the url so it includes a search param ?tab={DRUPAL ID OR TITLE OF TAB TO OPEN} (ex. https://deploy-preview-190--ugconthub.netlify.app/admission/undergraduate/requirements/canadian-transfer-students?tab=external-transfer or https://deploy-preview-190--ugconthub.netlify.app/admission/undergraduate/requirements/canadian-transfer-students?tab=c990a00e-13bb-4113-9d21-830ba30d826c)
4. Check the expected tab opened
5. Repeat with other pages and cases (ex. try an incorrect title/id, with multiple search params, etc.)