### PR TITLE
Ultrawide Hero

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "endOfLine": "lf",
-  "semi": false,
+  "semi": true,
   "singleQuote": false,
   "tabWidth": 2,
   "trailingComma": "es5",

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -5,7 +5,7 @@
 }
 
 #rotator {
-  /* Margin was originally needed for old header */
+  /* Margin was originally needed for old fixed position header */
   margin-top: 0 !important;
 }
 

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -21,3 +21,9 @@
   aspect-ratio: 1680 / 640;
   max-height: 75vh;
 }
+
+@media only screen and (min-width: 1080px) {
+  #rotator {
+    max-height: unset !important;
+  }
+}

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,14 +1,23 @@
-
 @media only screen and (max-width: 992px) {
-    #rotator img {
-        width: calc(100% + 10rem) !important;
-    }
+  #rotator img {
+    width: calc(100% + 10rem) !important;
+  }
+}
+
+#rotator {
+  /* Margin was originally needed for old header */
+  margin-top: 0 !important;
 }
 
 #rotator .hero-widgets-container {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 1;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+}
+
+#rotator .gatsby-image-wrapper {
+  aspect-ratio: 1680 / 640;
+  max-height: 75vh;
 }


### PR DESCRIPTION
# Summary of changes
Fixes the issue with the hero image being cutoff on the top and bottom on ultra wide displays the same way as on doorknob.


## Frontend
List all significant changes to Gatsby code

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

https://deploy-preview-194--ugconthub.netlify.app/

1. Go on any page with a hero image ex. https://deploy-preview-194--ugconthub.netlify.app/international/undergraduate-faqs/
2. Test the page at various breakpoints: mobile, desktop, laptop, ultra wide, etc.
3. Ensure the hero image isn't cutoff (or at least extremely cutoff) at all breakpoints.