### PR TITLE
Set gatsby-adapter-netlify to ^1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.3.2",
     "express": "^4.18.2",
     "gatsby": "^5.12.11",
-    "gatsby-adapter-netlify": "^1.1.3",
+    "gatsby-adapter-netlify": "^1.0.4",
     "gatsby-cli": "^5.12.4",
     "gatsby-graphiql-explorer": "^3.12.1",
     "gatsby-plugin-client-side-redirect": "^1.1.0",


### PR DESCRIPTION
# Summary of changes
Set gastby-adapter-entlify to ^1.0.4

I'm noticing build is behaving differently on preview. When the cache is fully cleared, it works, but then the next build it does not show the change.

# Test Plan
Review if build works as expected.