### PR TITLE
Testimonial widget: null check and refactoring

### DIFF
--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -7,100 +7,98 @@ import TestimonialTitle from 'components/shared/testimonialTitle';
 import { stripHTMLTags, setHeadingLevel } from 'utils/ug-utils.js';
 import 'styles/testimonial.css';
 
-function setTestimonialHeading (props) {
-	// heading passed through prop
-	if( props.heading ) {
-		return props.heading;
-	}
+function setTestimonialHeading(props) {
+    // heading passed through prop
+    if (props.heading) {
+        return props.heading;
+    }
 
-	// heading generated for program page
-	if ( props.programAcronym ) {
-		const testimonialTags = props.testimonialData.flatMap((testim) => {
-			let tag = TestimonialTitle(testim.node ?? testim);
-			return tag ?? [];
-		})
+    // heading generated for program page
+    if (props.programAcronym) {
+        
+        const testimonialTags = props.testimonialData.flatMap(testim => TestimonialTitle(testim.node ?? testim) ?? []);
 
-		let studentTag = testimonialTags.includes('Graduate Student', 'Undergraduate Student')
-		let facultyTag = testimonialTags.includes('Faculty')
-		let alumniTag = testimonialTags.includes('Alumni')
-	
-		// Testimonial heading generated for program pages
-		let testimonialHeading = studentTag && facultyTag && alumniTag ? "Alumni, Students, and Faculty from the program" : 
-			studentTag && !facultyTag && !alumniTag ? "Students from the program" :
-			studentTag && facultyTag && !alumniTag ? "Students and Faculty from the program":
-			studentTag && !facultyTag && alumniTag ? "Alumni and Students from the program":
-			!studentTag && facultyTag && alumniTag ? "Alumni and Faculty from the program":
-			!studentTag && facultyTag && !alumniTag ? "Faculty from the program" :
-			!studentTag && !facultyTag && alumniTag ? "Alumni from the program" : "Students in the program"
-	
-		return ("What " + testimonialHeading + " are saying about U of G");
-	}
+        const studentTag = testimonialTags.includes('Graduate Student', 'Undergraduate Student')
+        const facultyTag = testimonialTags.includes('Faculty')
+        const alumniTag = testimonialTags.includes('Alumni')
+    
+        // Testimonial heading generated for program pages
+        let testimonialHeading = studentTag && facultyTag && alumniTag ? "Alumni, Students, and Faculty" : 
+            studentTag && !facultyTag && !alumniTag ? "Students from" :
+            studentTag && facultyTag && !alumniTag ? "Students and Faculty from":
+            studentTag && !facultyTag && alumniTag ? "Alumni and Students from":
+            !studentTag && facultyTag && alumniTag ? "Alumni and Faculty from":
+            !studentTag && facultyTag && !alumniTag ? "Faculty from" :
+            !studentTag && !facultyTag && alumniTag ? "Alumni from" : "Students in"
+    
+        return ("What " + testimonialHeading + " the program are saying about U of G");
+    }
 }
 
 function Testimonials (props) {
-	let Heading = setHeadingLevel(props.headingLevel);
-	let testimonialHeading = setTestimonialHeading(props)
+    let Heading = setHeadingLevel(props.headingLevel);
+    let testimonialHeading = setTestimonialHeading(props)
 
-	if (props.testimonialData?.length > 0) {
-		const testimonialUnits  = () => props.testimonialData.map((testimonial) => {
-			// program queries are nested under .node and widget queries are not
-			let testimonialNode = testimonial.node ?? testimonial;
-			let testimonialName = testimonialNode.field_testimonial_person_name ?? testimonialNode.title;
-			let testimonialTitle = TestimonialTitle(testimonialNode);
-			let testimonialContent = stripHTMLTags(testimonialNode.body.processed);
-			let testimonialPicture = getImage(testimonialNode.relationships.field_hero_image?.relationships.field_media_image);
+    if (props.testimonialData?.length > 0) {
+        const testimonialUnits  = () => props.testimonialData.map((testimonial) => {
+            // program queries are nested under .node and widget queries are not
+            let testimonialNode = testimonial.node ?? testimonial;
+            let testimonialName = testimonialNode.field_testimonial_person_name ?? testimonialNode.title;
+            let testimonialTitle = TestimonialTitle(testimonialNode);
+            let testimonialContent = stripHTMLTags(testimonialNode.body.processed);
+            let testimonialPicture = getImage(testimonialNode.relationships.field_hero_image?.relationships.field_media_image);
     
-			const testimonialHomeProfile = () => {
-				let testimonialHomeProfileTitle = (testimonialNode.field_home_profile?.title === "") ? "Associated Profile" : testimonialNode.field_home_profile?.title;
-				let testimonialHomeProfileLink = testimonialNode.field_home_profile?.uri;
+            const testimonialHomeProfile = () => {
+                let testimonialHomeProfileTitle = (testimonialNode.field_home_profile?.title === "") ? "Associated Profile" : testimonialNode.field_home_profile?.title;
+                let testimonialHomeProfileLink = testimonialNode.field_home_profile?.uri;
 
-				if (testimonialHomeProfileLink) {
-					return <a href= {testimonialHomeProfileLink}>{testimonialHomeProfileTitle}</a>
-				} 
-				return null;
-			};
+                if (testimonialHomeProfileLink) {
+                    return <a href= {testimonialHomeProfileLink}>{testimonialHomeProfileTitle}</a>
+                } 
+                return null;
+            };
 
-			return (
-				<div key={testimonialNode.drupal_id}>
-					{testimonialPicture && 
-						<GatsbyImage image={testimonialPicture}
-							className="testimonial-pic"
-							alt={testimonialNode.relationships.field_hero_image.field_media_image.alt} />}
-					<blockquote className="testimonial-quote mb-0" dangerouslySetInnerHTML={{__html: testimonialContent}} />
-					<p className="testimonial-tagline author">
-						<strong className="testimonial-title">{testimonialName}{testimonialTitle ? ', ' + testimonialTitle : '' }</strong>
-						<br />
-						<span className="testimonial-person-desc">{testimonialNode.field_testimonial_person_desc}</span>
-						<br/>
-						{testimonialNode.field_home_profile && testimonialHomeProfile()}
-					</p>
-				</div>
-		);
-		})
-		return (
-			<div className="ug-testimonial">
-				<div className="full-width-container bg-light">
-					<div className="container page-container">
-						<section className="row row-with-vspace site-content">
-							<div className="col-md-12 content-area">
-								{testimonialHeading && <Heading className="carousel-header text-dark">{testimonialHeading}</Heading>}
-								<div className="testimonial-wrapper">
-									<SliderResponsive addToControlLabel="Testimonial">{testimonialUnits()}</SliderResponsive>
-								</div>
-							</div>
-						</section>
-					</div>
-				</div>
-			</div>
-		)
+            return (
+                <div key={testimonialNode.drupal_id}>
+                    {testimonialPicture && 
+                        <GatsbyImage image={testimonialPicture}
+                            className="testimonial-pic"
+                            alt={testimonialNode.relationships.field_hero_image.field_media_image.alt} />}
+                    <blockquote className="testimonial-quote mb-0" dangerouslySetInnerHTML={{__html: testimonialContent}} />
+                    <p className="testimonial-tagline author">
+                        <strong className="testimonial-title">{testimonialName}{testimonialTitle ? ', ' + testimonialTitle : '' }</strong>
+                        <br />
+                        <span className="testimonial-person-desc">{testimonialNode.field_testimonial_person_desc}</span>
+                        <br/>
+                        {testimonialNode.field_home_profile && testimonialHomeProfile()}
+                    </p>
+                </div>
+        );
+        })
+        return (
+            <div className="ug-testimonial">
+                <div className="full-width-container bg-light">
+                    <div className="container page-container">
+                        <section className="row row-with-vspace site-content">
+                            <div className="col-md-12 content-area">
+                                {testimonialHeading && <Heading className="carousel-header text-dark">{testimonialHeading}</Heading>}
+                                <div className="testimonial-wrapper">
+                                    <SliderResponsive addToControlLabel="Testimonial">{testimonialUnits()}</SliderResponsive>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </div>
+        )
 
-	} else {
-		return null
-	}
+    } else {
+        return null
+    }
 }
 
 Testimonials.propTypes = {
-	testimonialData: PropTypes.array,
+    testimonialData: PropTypes.array,
 }
 
 Testimonials.defaultProps = {
@@ -109,51 +107,50 @@ Testimonials.defaultProps = {
 
 export default Testimonials
 
-
 export const query = graphql`
-	fragment TestimonialNodeFragment on node__testimonial {
-		changed
-		drupal_id
-		body {
-			processed
-		}
-		title
-		field_testimonial_person_name
-		field_testimonial_person_desc
-		field_home_profile {
-			title
-			uri
-		}
-		relationships {
-			field_hero_image {
-				field_media_image {
-					alt
-				}
-				relationships {
-					field_media_image {
-						gatsbyImage(
-							width: 400
-							height: 400
-							placeholder: BLURRED
-							layout: CONSTRAINED
-							formats: [AUTO, WEBP]
-						)
-					}
-				}
-			}
-			field_testimonial_type {
-				drupal_id
-				id
-				name
-			}
-			field_tags {
-				__typename
-				... on TaxonomyInterface {
-					drupal_id
-					id
-					name
-				}
-			}
-		}
-	}
+  fragment TestimonialNodeFragment on node__testimonial {
+    changed
+    drupal_id
+    body {
+      processed
+    }
+    title
+    field_testimonial_person_name
+    field_testimonial_person_desc
+    field_home_profile {
+      title
+      uri
+    }
+    relationships {
+      field_hero_image {
+        field_media_image {
+          alt
+        }
+        relationships {
+          field_media_image {
+            gatsbyImage(
+              width: 400
+              height: 400
+              placeholder: BLURRED
+              layout: CONSTRAINED
+              formats: [AUTO, WEBP]
+            )
+          }
+        }
+      }
+      field_testimonial_type {
+        drupal_id
+        id
+        name
+      }
+      field_tags {
+        __typename
+        ... on TaxonomyInterface {
+          drupal_id
+          id
+          name
+        }
+      }
+    }
+  }
 `

--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -24,14 +24,13 @@ function setTestimonialHeading(props) {
     
         // Testimonial heading generated for program pages
         let testimonialHeading = studentTag && facultyTag && alumniTag ? "Alumni, Students, and Faculty" : 
-            studentTag && !facultyTag && !alumniTag ? "Students from" :
-            studentTag && facultyTag && !alumniTag ? "Students and Faculty from":
-            studentTag && !facultyTag && alumniTag ? "Alumni and Students from":
-            !studentTag && facultyTag && alumniTag ? "Alumni and Faculty from":
-            !studentTag && facultyTag && !alumniTag ? "Faculty from" :
-            !studentTag && !facultyTag && alumniTag ? "Alumni from" : "Students in"
+            studentTag && facultyTag && !alumniTag ? "Students and Faculty" :
+            studentTag && !facultyTag && alumniTag ? "Alumni and Students" :
+            !studentTag && facultyTag && alumniTag ? "Alumni and Faculty" :
+            !studentTag && facultyTag && !alumniTag ? "Faculty" :
+            !studentTag && !facultyTag && alumniTag ? "Alumni" : "Students"
     
-        return ("What " + testimonialHeading + " the program are saying about U of G");
+        return `What ${testimonialHeading === "Students" ? "Students in " : testimonialHeading + " from"} the program are saying about U of G`;
     }
 }
 

--- a/src/components/shared/testimonial.js
+++ b/src/components/shared/testimonial.js
@@ -18,9 +18,9 @@ function setTestimonialHeading(props) {
         
         const testimonialTags = props.testimonialData.flatMap(testim => TestimonialTitle(testim.node ?? testim) ?? []);
 
-        const studentTag = testimonialTags.includes('Graduate Student', 'Undergraduate Student')
-        const facultyTag = testimonialTags.includes('Faculty')
-        const alumniTag = testimonialTags.includes('Alumni')
+        const studentTag = testimonialTags.includes('Graduate Student', 'Undergraduate Student');
+        const facultyTag = testimonialTags.includes('Faculty');
+        const alumniTag = testimonialTags.includes('Alumni');
     
         // Testimonial heading generated for program pages
         let testimonialHeading = studentTag && facultyTag && alumniTag ? "Alumni, Students, and Faculty" : 
@@ -72,7 +72,7 @@ function Testimonials (props) {
                         {testimonialNode.field_home_profile && testimonialHomeProfile()}
                     </p>
                 </div>
-        );
+            );
         })
         return (
             <div className="ug-testimonial">

--- a/src/components/shared/testimonialSlider.js
+++ b/src/components/shared/testimonialSlider.js
@@ -21,7 +21,7 @@ const TestimonialSlider = (props) => {
 
   let testimonialTitle = props.testimonialData.field_title;
 
-  // handle testimonials added individually
+  // handle testimonials added by title
   let testimonialNodes = props.testimonialData.relationships?.field_testimonial_nodes || [];
 
   // handle testimonials added by tag

--- a/src/components/shared/testimonialSlider.js
+++ b/src/components/shared/testimonialSlider.js
@@ -7,7 +7,9 @@ const myUnionBy = (arrays, iteratee) => {
 
   arrays.forEach((array) => {
     array.forEach((object) => {
-      map[object[iteratee]] = object;
+      if (object !== null && object !== undefined) {
+        map[object[iteratee]] = object;
+      }
     });
   });
 

--- a/src/components/shared/testimonialSlider.js
+++ b/src/components/shared/testimonialSlider.js
@@ -15,13 +15,17 @@ const myUnionBy = (arrays, iteratee) => {
 };
 
 const TestimonialSlider = (props) => {
-  let testimonialTitle = props.testimonialData?.field_title;
+  if (!props.testimonialData) {
+    return null;
+  }
+
+  let testimonialTitle = props.testimonialData.field_title;
 
   // handle testimonials added individually
-  let testimonialNodes = props.testimonialData.relationships?.field_testimonial_nodes;
+  let testimonialNodes = props.testimonialData.relationships?.field_testimonial_nodes || [];
 
   // handle testimonials added by tag
-  let testimonialTags = props.testimonialData.relationships?.field_tags;
+  let testimonialTags = props.testimonialData.relationships?.field_tags || [];
   let testimonialTaggedNodes = testimonialTags.flatMap((tag) => {
     return tag.relationships.node__testimonial;
   })
@@ -29,7 +33,7 @@ const TestimonialSlider = (props) => {
   // remove duplicate values from array of objects using drupal_id + limit to 10 testimonials
   let testimonialData = myUnionBy([testimonialNodes, testimonialTaggedNodes], 'drupal_id').slice(0,10);
 
-  return testimonialData ? 
+  return testimonialData.length > 0 ? 
     <Testimonials
       testimonialData={testimonialData}
       headingLevel="h3"
@@ -37,6 +41,7 @@ const TestimonialSlider = (props) => {
     />
     : null
 }
+
 
 export default TestimonialSlider
 

--- a/src/components/shared/testimonialTitle.js
+++ b/src/components/shared/testimonialTitle.js
@@ -1,16 +1,15 @@
 import PropTypes from 'prop-types';
 
-function TestimonialTitle (props){
-    let typeList = props?.relationships.field_testimonial_type.map((testimonialType) => {
-		return testimonialType.name;
-	})
+/**
+* Return first type found in typeList from the types array. If no match found, return null. 
+* The order of types in the array determines priority. The earlier a type appears, the higher its priority.
+**/
 
-	let highestTestimonialType = typeList.includes('Faculty') ? 'Faculty' : 
-			typeList.includes('Alumni') ? 'Alumni' : 
-			typeList.includes('Graduate Student') ? 'Graduate Student' : 
-			typeList.includes('Undergraduate Student') ? 'Undergraduate Student' : null;
+function TestimonialTitle(props) {
+    const typeList = props?.relationships.field_testimonial_type.map(testimonialType => testimonialType.name);
+    const types = ['Faculty', 'Alumni', 'Graduate Student', 'Undergraduate Student'];
 
-	return highestTestimonialType;
+    return types.find(type => typeList.includes(type)) || null;
 }
 
 TestimonialTitle.propTypes = {


### PR DESCRIPTION
# Summary of changes
Create a null check to resolve the following[ build error](https://app.netlify.com/sites/preview-ugconthub/deploys/65c102f368b910000808ceaf) that occurs when an empty testimonial widget is added to a page:

```
   error Truncated page data information for the failed page "/people/": {
   "errors": {},
   "path": "/people/",
   "slicesMap": {},
   "pageContext": {
     "id": "256770e6-15f6-57c3-9dce-a0d1cf43f977",
     "nid": "entity:node/2780",
     "tid": [
       "791cb49e-41a9-5a82-9bb1-7560894adcb3"
     ]
   }
 }
 failed Building static HTML for pages - 5.372s
 error Building static HTML failed for path "/people/"
 
    8 |   arrays.forEach((array) => {
    9 |     array.forEach((object) => {
 > 10 |       map[object[iteratee]] = object;
      |                 ^
   11 |     });
   12 |   });
```

## Frontend
- Add proper null check to `myUnionBy` function in `testimonial.js`
- Refactor and streamline testimonial code
- Replace tabs with spaces

[ x ] My changes are accessible (at minimum WCAG 2.0 Level AA)
[ x ] My changes are responsive and appear as expected on mobile and desktop views.
[ N/A ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None (though we might consider some later on, e.g. why bother permitting multiple selections for Testimonial type and offering a "Staff" option when it's not being used)

# Test Plan

- Go to https://fixtestimonials--test-ugconthub.netlify.app/test-testimonials/ and verify the empty testimonial widgets do not render while the ones that have content do (backend version of this page is at https://tq-ginfix-chug.pantheonsite.io/node/2784/edit)
- Go to https://fixtestimonials--test-ugconthub.netlify.app/programs/bachelor-of-science-in-agriculture/ and verify all testimonial types display and are mentioned in the title 
- Go to https://fixtestimonials--test-ugconthub.netlify.app/programs/bachelor-of-engineering/ and verify the single Student testimonial displays as expected

## Known Issues

If you go to https://fixtestimonials--test-ugconthub.netlify.app/programs/bachelor-of-bio-resource-management/ the testimonial title is incorrect - it only mentions alumni when it should also mention students. However, this bug occurs on production as well and is unrelated to this PR: https://www.uoguelph.ca/programs/bachelor-of-bio-resource-management/