### PR TITLE
using env variable for web component cdn url

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,8 @@
 import React from "react";
 
-const UNPKG_WC_CDN = "https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components";
+const wcBase = new URL(process.env.UOFG_WC_BASE_URL || "https://unpkg.com/@uoguelph/web-components@1.x.x");
+const wcJS = new URL("dist/uofg-web-components/uofg-web-components.esm.js", wcBase);
+const wcCSS = new URL("dist/uofg-web-components/uofg-web-components.css", wcBase);
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   setHeadComponents([
@@ -8,16 +10,8 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       key="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
       src="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
     />,
-    <script
-      type="module"
-      src={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.esm.js`}
-      key={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.esm.js`}
-    />,
-    <link
-      rel="stylesheet"
-      href={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.css`}
-      key={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.css`}
-    />,
+    <script type="module" src={wcJS} key={wcJS} />,
+    <link rel="stylesheet" href={wcCSS} key={wcCSS} />,
     <link rel="preconnect" href="https://fonts.googleapis.com" key="https://fonts.googleapis.com" />,
     <link rel="preconnect" href="https://fonts.gstatic.com" key="https://fonts.gstatic.com" crossOrigin="anonymous" />,
     <link

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,8 +1,8 @@
 import React from "react";
 
-const wcBase = new URL(process.env.UOFG_WC_BASE_URL || "https://unpkg.com/@uoguelph/web-components@1.x.x");
-const wcJS = new URL("dist/uofg-web-components/uofg-web-components.esm.js", wcBase);
-const wcCSS = new URL("dist/uofg-web-components/uofg-web-components.css", wcBase);
+const wcVersion = process.env.UOFG_WC_VERSION || "1.x.x";
+const wcJS = `https://unpkg.com/@uoguelph/web-components@${wcVersion}/dist/uofg-web-components/uofg-web-components.esm.js`;
+const wcCSS = `https://unpkg.com/@uoguelph/web-components@${wcVersion}/dist/uofg-web-components/uofg-web-components.css`;
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   setHeadComponents([

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,62 +1,54 @@
-import React from 'react';
+import React from "react";
+
+const UNPKG_WC_CDN = "https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components";
 
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
-  
-    setHeadComponents([
-        <script 
-            key="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
-            src="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
-        />,
-        <script
-            type="module"
-            src="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.esm.js"
-            key="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.esm.js"
-        />,
-        <link
-            rel="stylesheet"
-            href="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.css"
-            key="https://unpkg.com/@uoguelph/web-components@1.x.x/dist/uofg-web-components/uofg-web-components.css"
-        />,
-        <link
-            rel="preconnect"
-            href="https://fonts.googleapis.com"
-            key="https://fonts.googleapis.com"
-        />,
-        <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            key="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-        />,
-        <link
-            href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
-            key="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
-            rel="stylesheet"
-        />,
-        <link
-            key="https://www.uoguelph.ca/css/UofG-styles-dist.css" 
-            rel="stylesheet" 
-            href="https://www.uoguelph.ca/css/UofG-styles-dist.css" 
-        />,
-    ])
+  setHeadComponents([
+    <script
+      key="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
+      src="https://cdn.bc0a.com/autopilot/f00000000209359/autopilot_sdk.js"
+    />,
+    <script
+      type="module"
+      src={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.esm.js`}
+      key={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.esm.js`}
+    />,
+    <link
+      rel="stylesheet"
+      href={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.css`}
+      key={`${process.env.UOFG_WC_BASE_URL || UNPKG_WC_CDN}/uofg-web-components.css`}
+    />,
+    <link rel="preconnect" href="https://fonts.googleapis.com" key="https://fonts.googleapis.com" />,
+    <link rel="preconnect" href="https://fonts.gstatic.com" key="https://fonts.gstatic.com" crossOrigin="anonymous" />,
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
+      key="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
+      rel="stylesheet"
+    />,
+    <link
+      key="https://www.uoguelph.ca/css/UofG-styles-dist.css"
+      rel="stylesheet"
+      href="https://www.uoguelph.ca/css/UofG-styles-dist.css"
+    />,
+  ]);
 
-    setPostBodyComponents([
-        <script
-            key="https://kit.fontawesome.com/7993323d0c.js"
-            src="https://kit.fontawesome.com/7993323d0c.js"
-            crossOrigin="anonymous"
-            defer
-        />,
-        <script
-            key="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-            src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-            crossOrigin="anonymous"
-            defer
-        />,
-        <script 
-            key="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js"
-            src="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js" 
-            defer 
-        />
-    ])
-}
+  setPostBodyComponents([
+    <script
+      key="https://kit.fontawesome.com/7993323d0c.js"
+      src="https://kit.fontawesome.com/7993323d0c.js"
+      crossOrigin="anonymous"
+      defer
+    />,
+    <script
+      key="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
+      crossOrigin="anonymous"
+      defer
+    />,
+    <script
+      key="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js"
+      src="https://www.uoguelph.ca/js/uog-scripts-gatsby-dist.js"
+      defer
+    />,
+  ]);
+};


### PR DESCRIPTION
# Summary of changes
Rather than having the version for the web components nom package hardcoded, I changed it so it is using a env variable. This will allow us to set the env variable on Netlify (which I have already done) so that we can have the preview builds use beta versions of the npm package.

## Frontend
- updated gatsby-ssr.js to use env variable instead of hardcoded url

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

- Test that the changes to the top nav are appearing (see https://github.com/ccswbs/web-components/pull/12 for more info.)
- Ensure nothing has broken