### PR TITLE
Downgrade react-slick to resolve single testimonial bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "react-number-format": "^5.3.3",
         "react-player": "^2.15.1",
         "react-portal": "^4.2.2",
-        "react-slick": "^0.30.2",
+        "react-slick": "0.29.0",
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.8"
       },
@@ -16971,10 +16971,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
       "inBundle": true,
@@ -20688,9 +20684,9 @@
       }
     },
     "node_modules/react-slick": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
-      "integrity": "sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
       "dependencies": {
         "classnames": "^2.2.5",
         "enquire.js": "^2.1.6",
@@ -36328,9 +36324,6 @@
             "validate-npm-package-name": "^5.0.0"
           }
         },
-        "ip": {
-          "version": "2.0.0"
-        },
         "ip-address": {
           "version": "9.0.5",
           "bundled": true,
@@ -39031,9 +39024,9 @@
       "requires": {}
     },
     "react-slick": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.30.2.tgz",
-      "integrity": "sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.29.0.tgz",
+      "integrity": "sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==",
       "requires": {
         "classnames": "^2.2.5",
         "enquire.js": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-number-format": "^5.3.3",
     "react-player": "^2.15.1",
     "react-portal": "^4.2.2",
-    "react-slick": "^0.30.2",
+    "react-slick": "0.29.0",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.8"
   },


### PR DESCRIPTION
# Summary of changes
Hotfix for issue where testimonial sliders with a single testimonial shows 3 duplicates in a column.

## Frontend
Downgrade `react-slick` to v0.29.0

# Test Plan
Go to https://deploy-preview-207--ugconthub.netlify.app/engineering/undergraduate/future-students/computer/ and https://deploy-preview-207--ugconthub.netlify.app/programs/bachelor-of-engineering/ and verify the testimonial displays properly.