### PR TITLE
Allow pages associated with disabled menu links to show their menus

### DIFF
--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -84,7 +84,7 @@ const generateMenu = (menuLinks, menuName) => {
 
   return (
     <>
-      {pageHome.title != null && (
+      {pageHome && pageHome.title != null && (
         <uofg-header page-title={pageHome.title} page-url={pageHome.link.url}>
           {menuItems}
         </uofg-header>

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -105,7 +105,7 @@ export const query = graphql`
       }
     }
 
-    menu: menuLinkContentMenuLinkContent(link: {uri: {eq: $nid}}, enabled: {eq: true}) {
+    menu: menuLinkContentMenuLinkContent(link: {uri: {eq: $nid}}) {
       link {
         uri
         url


### PR DESCRIPTION
# Summary of changes
Allow pages associated with disabled menu links to show their menus

## Frontend
Allow pages associated with disabled menu links to show their menus

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Ensure sample page /president/sustainability shows its menu.