### PR TITLE
Set default of media and text widget heading to h3

### DIFF
--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -39,7 +39,7 @@ function MediaText (props) {
     let headingClass;
     let headingColor;
     let textOrButtons = mediaDescription || mediaButtons ? true : false;
-    let HeadingLevel = (props.widgetData?.field_heading_level ? props.widgetData.field_heading_level : "h2");
+    let HeadingLevel = (props.widgetData?.field_heading_level ? props.widgetData.field_heading_level : "h3");
     
     switch(mediaBgColor) {
         case "Light Blue":


### PR DESCRIPTION
# Summary of changes
The original default of the media and text widget was an h3, so we are reverting back to that default.

## Frontend
Set default of media and text widget heading to h3

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Review the deployment and see if wide-spread issues with nested headings are fixed.
2. Review pages like https://deploy-preview-210--ugconthub.netlify.app/healthy-campus/