### PR TITLE
Fix blurred images on Story Image and Image Overlay

### DIFF
--- a/src/components/shared/imageOverlay.js
+++ b/src/components/shared/imageOverlay.js
@@ -315,7 +315,7 @@ export const query = graphql`
                 width: 1400, 
                 placeholder: BLURRED, 
                 layout: CONSTRAINED,
-                cropFocus: ENTROPY,
+                cropFocus: CENTER,
                 formats: [AUTO, WEBP],
               )
             }

--- a/src/components/shared/storyImageCutout.js
+++ b/src/components/shared/storyImageCutout.js
@@ -171,7 +171,7 @@ export const query = graphql`
                 height: 600,
                 placeholder: BLURRED, 
                 layout: CONSTRAINED,
-                cropFocus: ENTROPY,
+                cropFocus: CENTER,
                 formats: [AUTO, WEBP],
               )
             }


### PR DESCRIPTION
# Summary of changes
Entropy is not supported by Netlify Image CDN. Replacing the focus with CENTER instead.

## Frontend
Swapped Story Image and Image Overlay widgets to use CENTER focus instead of ENTROPY.

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None.

# Test Plan

1. Ensure image shows on image overlay at /research/innovation
2. Ensure image shows in story image at /lang/commerce/expertise