### PR TITLE
Bcrumfix

### DIFF
--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -89,31 +89,56 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
         }
         
         return (<>
-            <div className="breadcrumbs loaded">
                 <div className="container">
                     <div className="row">
                         <div className="col-sm-12">
-                            <div className="site-breadcrumbs">          
-                            <ol className="breadcrumb breadcrumb-right-tag">                                
-                                <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
-                                    <a href={homeCrumbURL}>
-                                        <i aria-hidden="true" className="fa-sharp fa-light fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
-                                    </a>
-                                </li>
-                                {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
-                                    <li key={topCrumbURL} className="breadcrumb-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
-                                {midCrumbs && midCrumbs.map(midCrumb => {
-                                    return <><li key={midCrumb.node.link.url + `mid`} className="breadcrumb-item">
-                                            <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
-                                    </li></>
-                                })}
-                                <li key={endCrumb + `end`} className="breadcrumb-item">{endCrumb ? endCrumb : pageTitle}</li>                           
-                            </ol>
+                            <div className='gus-breadcrumbs gus-breadcrumbs--collapse-on-mobile'>
+                                <ol className="gus-breadcrumbs__list">                                
+                                    <li key={homeCrumbURL + `home`} className="gus-breadcrumbs__list-item">                                    
+                                        <a href={homeCrumbURL}>
+                                            <i aria-hidden="true" className="fa-sharp fa-light fa-home gus-breadcrumb__link"></i><span className="visually-hidden">{homeCrumb}</span>
+                                        </a>
+                                    </li>
+                                    {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
+                                        <li key={topCrumbURL} className="gus-breadcrumbs__list-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
+                                    {midCrumbs && midCrumbs.map(midCrumb => {
+                                        return <><li key={midCrumb.node.link.url + `mid`} className="gus-breadcrumbs__list-item">
+                                                <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
+                                        </li></>
+                                    })}
+                                    <li key={endCrumb + `end`} className="gus-breadcrumbs__list-item active" aria-current="page">{endCrumb ? endCrumb : pageTitle}</li>                           
+                                </ol>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
+            {/* <nav aria-label="breadcrumb">
+                <div className="breadcrumbs loaded">
+                    <div className="container">
+                        <div className="row">
+                            <div className="col-sm-12">
+                                <div className="site-breadcrumbs">          
+                                <ol className="breadcrumb breadcrumb-right-tag">                                
+                                    <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
+                                        <a href={homeCrumbURL}>
+                                            <i aria-hidden="true" className="fa-sharp fa-light fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
+                                        </a>
+                                    </li>
+                                    {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
+                                        <li key={topCrumbURL} className="breadcrumb-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
+                                    {midCrumbs && midCrumbs.map(midCrumb => {
+                                        return <><li key={midCrumb.node.link.url + `mid`} className="breadcrumb-item">
+                                                <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
+                                        </li></>
+                                    })}
+                                    <li key={endCrumb + `end`} className="breadcrumb-item active" aria-current="page">{endCrumb ? endCrumb : pageTitle}</li>                           
+                                </ol>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </nav> */}
         </>)        
     }
     return null;

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -89,29 +89,31 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
         }
         
         return (<>
-                <div className="container">
-                    <div className="row">
-                        <div className="col-sm-12">
-                            <div className='gus-breadcrumbs gus-breadcrumbs--collapse-on-mobile'>
-                                <ol className="gus-breadcrumbs__list">                                
-                                    <li key={homeCrumbURL + `home`} className="gus-breadcrumbs__list-item">                                    
-                                        <a href={homeCrumbURL}>
-                                            <i aria-hidden="true" className="fa-sharp fa-light fa-home gus-breadcrumb__link"></i><span className="visually-hidden">{homeCrumb}</span>
-                                        </a>
-                                    </li>
-                                    {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
-                                        <li key={topCrumbURL} className="gus-breadcrumbs__list-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
-                                    {midCrumbs && midCrumbs.map(midCrumb => {
-                                        return <><li key={midCrumb.node.link.url + `mid`} className="gus-breadcrumbs__list-item">
-                                                <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
-                                        </li></>
-                                    })}
-                                    <li key={endCrumb + `end`} className="gus-breadcrumbs__list-item active" aria-current="page">{endCrumb ? endCrumb : pageTitle}</li>                           
-                                </ol>
+                <nav aria-label="breadcrumb">
+                    <div className="container">
+                        <div className="row">
+                            <div className="col-sm-12">
+                                <div className='gus-breadcrumbs gus-breadcrumbs--collapse-on-mobile'>
+                                    <ol className="gus-breadcrumbs__list">                                
+                                        <li key={homeCrumbURL + `home`} className="gus-breadcrumbs__list-item">                                    
+                                            <a href={homeCrumbURL}>
+                                                <i aria-hidden="true" className="fa-sharp fa-light fa-home gus-breadcrumb__link"></i><span className="visually-hidden">{homeCrumb}</span>
+                                            </a>
+                                        </li>
+                                        {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
+                                            <li key={topCrumbURL} className="gus-breadcrumbs__list-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
+                                        {midCrumbs && midCrumbs.map(midCrumb => {
+                                            return <><li key={midCrumb.node.link.url + `mid`} className="gus-breadcrumbs__list-item">
+                                                    <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
+                                            </li></>
+                                        })}
+                                        <li key={endCrumb + `end`} className="gus-breadcrumbs__list-item active" aria-current="page">{endCrumb ? endCrumb : pageTitle}</li>                           
+                                    </ol>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
+                </nav>
             {/* <nav aria-label="breadcrumb">
                 <div className="breadcrumbs loaded">
                     <div className="container">

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -113,7 +113,7 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                             </div>
                         </div>
                     </div>
-                </nav>ß
+                </nav>
         </>)        
     }
     return null;

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -113,34 +113,7 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
                             </div>
                         </div>
                     </div>
-                </nav>
-            {/* <nav aria-label="breadcrumb">
-                <div className="breadcrumbs loaded">
-                    <div className="container">
-                        <div className="row">
-                            <div className="col-sm-12">
-                                <div className="site-breadcrumbs">          
-                                <ol className="breadcrumb breadcrumb-right-tag">                                
-                                    <li key={homeCrumbURL + `home`} className="breadcrumb-item">                                    
-                                        <a href={homeCrumbURL}>
-                                            <i aria-hidden="true" className="fa-sharp fa-light fa-home"></i><span className="visually-hidden">{homeCrumb}</span>
-                                        </a>
-                                    </li>
-                                    {menuName !== "main" && topCrumbURL && topCrumbID !== currentPage && 
-                                        <li key={topCrumbURL} className="breadcrumb-item"><Link to={topCrumbURL}>{topCrumb}</Link></li>}
-                                    {midCrumbs && midCrumbs.map(midCrumb => {
-                                        return <><li key={midCrumb.node.link.url + `mid`} className="breadcrumb-item">
-                                                <Link to={midCrumb.node.link.url}>{midCrumb.node.title}</Link>
-                                        </li></>
-                                    })}
-                                    <li key={endCrumb + `end`} className="breadcrumb-item active" aria-current="page">{endCrumb ? endCrumb : pageTitle}</li>                           
-                                </ol>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </nav> */}
+                </nav>ß
         </>)        
     }
     return null;

--- a/src/styles/breadcrumbs.css
+++ b/src/styles/breadcrumbs.css
@@ -21,7 +21,7 @@
     color:#0b0c0c;
     text-decoration: underline;
 }
-  @media (min-width: 40.0625em) {
+  @media (min-width: 576px) {
     .gus-breadcrumbs {
       font-size: 1rem;
       line-height: 1.25;

--- a/src/styles/breadcrumbs.css
+++ b/src/styles/breadcrumbs.css
@@ -1,3 +1,73 @@
 .breadcrumb-right-tag .breadcrumb-item:last-child  {
     max-width: none !important;
 }
+
+.gus-breadcrumbs {
+    font-size: 1.5rem !important;
+    line-height:2.2rem !important;
+    color: #0b0c0c;
+    width: 100%;
+    height: 4.2rem;
+    position:relative;
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+.gus-breadcrumbs a {
+    color:#0b0c0c;
+    text-decoration: none;
+}
+.gus-breadcrumbs a:hover {
+    color:#0b0c0c;
+    text-decoration: underline;
+}
+  @media (min-width: 40.0625em) {
+    .gus-breadcrumbs {
+      font-size: 1rem;
+      line-height: 1.25;
+    }
+  }
+  
+  .gus-breadcrumbs__list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+  .gus-breadcrumbs__list::after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+  
+  .gus-breadcrumbs__list-item {
+    display: inline-block;
+    position: relative;
+    margin-bottom: 5px;
+    margin-left: 0.625em;
+    padding-left: 0.9784375em;
+    float: left;
+  }
+  .gus-breadcrumbs__list-item::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: -0.206875em;
+    width: 0.4375em;
+    height: 0.4375em;
+    margin: auto 0;
+    transform: rotate(45deg);
+    border: solid;
+    border-width: 1px 1px 0 0;
+    border-color: #505a5f;
+  }
+ 
+  .gus-breadcrumbs__list-item:first-child {
+    margin-left: 0;
+    padding-left: 0;
+  }
+  .gus-breadcrumbs__list-item:first-child::before {
+    content: none;
+    display: none;
+  }
+  

--- a/src/styles/breadcrumbs.css
+++ b/src/styles/breadcrumbs.css
@@ -9,7 +9,8 @@
     width: 100%;
     height: 4.2rem;
     position:relative;
-    margin-top: 0px;
+    margin-top: 10px;
+    margin-left: 5px;
     margin-bottom: 0px;
   }
 .gus-breadcrumbs a {


### PR DESCRIPTION
# Summary of changes
Bread Crumb Fix -[Bug 76552](https://dev.azure.com/uoguelph/CCS/_workitems/edit/76552): Breadcrumb is arbitrarily cut short : UI for Desktop and Mobile: Phase 1 release 

## Frontend
src/styles/breadcrumbs.css : Added custom CSS to use instead of the CCS provided by UofG Styles as I was overriding them all with !important - so it was cleaner to just have this fix. 
src/.components/shared/breadcrumbs.js : changed the classes to use the new CSS to wrap the breadcrumbs. 

This is only fixes the issue by wrapping the breadcrumbs, the shortening by replacing items with ... will be phase 2. 

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
List all significant changes to the Drupal site (e.g. new fields, content types, modules, etc). If adding new fields, try to include help text to ensure users understand how to use the fields.

No changes!

# Test Plan

Open a page with a long breadcrumb list and see if it is responsive to different screen sizes. 

https://deploy-preview-225--ugconthub.netlify.app/
[
](https://deploy-preview-225--ugconthub.netlify.app/clinical-studies/faculty/henry-st%C3%A4mpfli/)