### PR TITLE
update to drupal 10

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -304,6 +304,8 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       title: String
       body: BodyFieldWithSummary
       field_hero_image: ImageField
+      field_news_author: String
+      field_lead_image: String
       relationships: node__articleRelationships
       fields: node__articleFields
       path: AliasPath
@@ -311,6 +313,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type node__articleRelationships implements Node {
       field_hero_image: media__image @link(from: "field_hero_image___NODE")
       field_news_category: [taxonomy_term__news_category] @link(from: "field_news_category___NODE")
+      field_news_topics: [taxonomy_term__news_topics] @link(from: "field_news_topics___NODE")
       field_tags: [relatedTaxonomyUnion] @link(from: "field_tags___NODE")
     }
     type node__articleFields implements Node {
@@ -830,6 +833,12 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       name: String
       field_menu_machine_name: String
     }
+    type taxonomy_term__news_topics implements Node & TaxonomyInterface {
+      drupal_id: String
+      drupal_internal__tid: Int
+      name: String
+      description: TaxonomyDescription
+    }
     type taxonomy_term__programs implements Node & TaxonomyInterface {
       drupal_id: String
       drupal_internal__tid: Int
@@ -995,6 +1004,7 @@ exports.onCreateWebpackConfig = (helper) => {
 exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
   // INSTRUCTION: Add new page templates here (e.g. you may want a new template for a new content type)
   const pageTemplate = path.resolve("./src/templates/page.js");
+  const articleTemplate = path.resolve('./src/templates/article-page.js');
   const programTemplate = path.resolve("./src/templates/program-page.js");
   const { createRedirect } = actions;
 
@@ -1038,6 +1048,22 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
   const result = await graphql(`
     {
       pages: allNodePage(filter: { path: { alias: { ne: null } }, moderation_state: { ne: "archived" } }) {
+        edges {
+          node {
+            id
+            drupal_id
+            drupal_internal__nid
+            title
+            fields {
+              tags
+            }
+            path {
+              alias
+            }
+          }
+        }
+      }
+      articles: allNodeArticle {
         edges {
           node {
             id
@@ -1101,7 +1127,20 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         );
       });
     }
-
+    // process article nodes
+    if (result.data.articles !== undefined) {
+    const articles = result.data.articles.edges;
+    articles.forEach(( { node }, index) => {
+        aliases[node.drupal_internal__nid] = processNews(
+            node,
+            node.id,
+            node.drupal_internal__nid,
+            node.fields.tags,
+            articleTemplate,
+            helpers
+        );
+    })
+  }
     // process program nodes
     if (result.data.programs !== undefined) {
       const programs = result.data.programs.edges;
@@ -1151,7 +1190,25 @@ function processPage(node, contextID, nodeNid, tagID, nodePath, nodeTitle, templ
   });
   return alias;
 }
+function processNews(node, contextID, nodeNid, tagID, template, helpers) {
+  let alias = createNewsContentTypeAlias(node);
 
+ helpers.createPage({
+   path: alias,
+   component: template,
+   context: {
+     id: contextID,
+     nid: `entity:node/` + nodeNid,
+     tid: tagID,
+   },
+ })
+ return alias;
+}
+function createNewsContentTypeAlias(node) {
+let  alias = `/news/` + slugify(node.title);
+console.log(alias, "news alias");
+return alias;
+}
 // use for content types
 function createContentTypeAlias(nodePath, nodeTitle) {
   let alias = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "gatsby-source-wordpress": "^7.13.3",
         "gatsby-transformer-sharp": "^5.13.1",
         "gatsby-transformer-yaml": "^5.13.1",
+        "html-react-parser": "^5.1.10",
         "html-to-react": "^1.7.0",
         "is-subset": "^0.1.1",
         "js-yaml": "^4.1.0",
@@ -13159,10 +13160,57 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
+      "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
       "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
+      "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.8",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.12"
+      },
+      "peerDependencies": {
+        "@types/react": "17 || 18",
+        "react": "0.14 || 15 || 16 || 17 || 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/html-to-react": {
       "version": "1.7.0",
@@ -21600,6 +21648,11 @@
         "react-dom": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -23477,6 +23530,27 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+      "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
+      "dependencies": {
+        "style-to-object": "1.0.6"
+      }
+    },
+    "node_modules/style-to-js/node_modules/inline-style-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
+    },
+    "node_modules/style-to-js/node_modules/style-to-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+      "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
+      "dependencies": {
+        "inline-style-parser": "0.2.3"
       }
     },
     "node_modules/style-to-object": {
@@ -34910,10 +34984,43 @@
         }
       }
     },
+    "html-dom-parser": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.0.8.tgz",
+      "integrity": "sha512-vuWiX9EXgu8CJ5m9EP5c7bvBmNSuQVnrY8tl0z0ZX96Uth1IPlYH/8W8VZ/hBajFf18EN+j2pukbCNd01HEd1w==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "9.1.0"
+      },
+      "dependencies": {
+        "htmlparser2": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+          "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.1.0",
+            "entities": "^4.5.0"
+          }
+        }
+      }
+    },
     "html-entities": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
       "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
+    },
+    "html-react-parser": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.1.10.tgz",
+      "integrity": "sha512-gV22PvLij4wdEdtrZbGVC7Zy2OVWnQ0bYhX63S196ZRSx4+K0TuutCreHSXr+saUia8KeKB+2TYziVfijpH4Tw==",
+      "requires": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.0.8",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.12"
+      }
     },
     "html-to-react": {
       "version": "1.7.0",
@@ -40754,6 +40861,11 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug=="
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -42162,6 +42274,29 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
+      }
+    },
+    "style-to-js": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.12.tgz",
+      "integrity": "sha512-tv+/FkgNYHI2fvCoBMsqPHh5xovwiw+C3X0Gfnss/Syau0Nr3IqGOJ9XiOYXoPnToHVbllKFf5qCNFJGwFg5mg==",
+      "requires": {
+        "style-to-object": "1.0.6"
+      },
+      "dependencies": {
+        "inline-style-parser": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+          "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
+        },
+        "style-to-object": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+          "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
+          "requires": {
+            "inline-style-parser": "0.2.3"
+          }
+        }
       }
     },
     "style-to-object": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gatsby-source-wordpress": "^7.13.3",
     "gatsby-transformer-sharp": "^5.13.1",
     "gatsby-transformer-yaml": "^5.13.1",
+    "html-react-parser": "^5.1.10",
     "html-to-react": "^1.7.0",
     "is-subset": "^0.1.1",
     "js-yaml": "^4.1.0",

--- a/src/components/shared/inlineImage.js
+++ b/src/components/shared/inlineImage.js
@@ -1,0 +1,105 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import HTMLReactParser, { domToReact } from "html-react-parser"
+import { propTypes } from "react-bootstrap/esm/Image"
+
+// This Function will take a string that contains HTML tags and parce it to add the BASEURL (environmental variable)
+// to the begining of the image source tag so that inline images placed by Drupal will have the proper URL. 
+// It will deal with the regular img tag as well as the figure tag (with caption) aswell as float the image start (left)
+// or end (right), or centre. The appropriate classes are added to format the image and add space between it and the text.
+// 
+// InlineImage() function will return an array of HTML tags that can be displayed directly. 
+
+
+
+function InlineImage(processed) {
+
+  const data = useStaticQuery(graphql`
+    query {
+      sitePlugin(name: {eq: "gatsby-source-drupal"}) {
+        pluginOptions
+      }
+    }
+  `)
+
+  const inlineImageSrc = (src, base) => {
+    if (src.charAt(0) === '/') 
+      return `${base}${src.substring(1)}`
+    else
+      return src
+  }
+
+  const inlineImageClass = (clazz) => {
+    if (clazz === 'align-left')
+      return 'd-block img-fluid float-md-start mx-auto me-4 mt-1 mb-3'
+    else if (clazz === 'align-right')
+      return 'd-block img-fluid float-md-end mx-auto ms-4 mt-1 mb-3'
+    else if (clazz === 'align-center')
+      return 'd-block img-fluid mx-auto mt-1 mb-3'
+    else if (clazz !== undefined)
+      return "img-fluid" + clazz
+    else
+      return "img-fluid"
+  }
+
+  const inlineFigureClass = (clazz) => {
+    const c = 'figure p-1';
+    if (clazz && clazz.match(/align-left/g))
+      return c + ' float-start mx-auto me-4 mt-1 mb-3'
+    else if (clazz && clazz.match(/align-right/g))
+      return c + ' float-end mx-auto ms-4 mt-1 mb-3'
+    else if (clazz && clazz.match(/align-center/g))
+      return c + ' d-block text-center mx-auto mt-1 mb-3'
+    else
+      return c
+  }
+
+  const replaceInlineImages = (domNode, baseUrl) => {
+    if (domNode.name === 'img') {
+      const src = domNode.attribs['src'];
+      const clazz = domNode.attribs['class'];
+      const imgClass = inlineImageClass(clazz);
+      const imgSrc   = inlineImageSrc(src, baseUrl);
+      const width    = domNode.attribs['width'];
+      const height   = domNode.attribs['height'];
+      const alt      = domNode.attribs['alt'];
+      return <img src={imgSrc} alt={alt} className={imgClass} width={width} height={height} />
+    }
+    if (domNode.name === 'figure') {
+      const clazz = domNode.attribs['class'];
+      const figclass = inlineFigureClass(clazz);
+      return <figure className={figclass}>
+        {domNode.children.map(child =>  replaceInlineImages(child, baseUrl))}
+      </figure>
+    }
+    if (domNode.name === 'figcaption') {
+      return <figcaption class="figure-caption">
+        {domToReact(domNode.children)}
+      </figcaption>
+    }
+    return undefined
+  }
+
+  const renderProcessed = () => {
+    const baseUrl = data.sitePlugin.pluginOptions.baseUrl;
+        if (typeof processed !== 'string') {
+        return <></>;
+        }
+        const parsed = HTMLReactParser(processed, {
+        replace: domNode => replaceInlineImages(domNode, baseUrl)
+        })
+        return parsed;
+
+  }
+
+ return renderProcessed ()
+}
+InlineImage.propTypes = {
+    processed: propTypes.string,
+}
+
+InlineImage.defaultProps = {
+    processed: ``,
+}
+
+export default InlineImage

--- a/src/templates/article-page.js
+++ b/src/templates/article-page.js
@@ -1,23 +1,90 @@
 import React from 'react';
 import { graphql } from 'gatsby';
+import CustomFooter from 'components/shared/customFooter';
+import Hero from 'components/shared/hero'; 
+import InlineImage from 'components/shared/inlineImage';
 import Layout from 'components/layout';
 import Seo from 'components/seo';
 
-export default ({data}) => {
+function contentExists(content) {
+    if (content && !Array.isArray(content)) {
+        return true;
+    } else if (content && Array.isArray(content) && content.length > 0) {
+        return true;
+    }
+	return false;
+}
+
+function ListAsButtons (props) {
+	let ButtonToDisplay = props
+	return (
+		<React.Fragment>
+			<span><a href="" className='btn btn-outline-info'>{ButtonToDisplay} </a>{" "}</span>
+		</React.Fragment>
+	)
+}
+const ArticlePage = ({data}) => {
+	console.log(data, "data")
 	const pageData = data.articles.edges[0].node;
-	const title = pageData.title;
-	const body = (pageData.body !== null ? pageData.body.processed:``);
+	const pageTitle = pageData.title;
+	const author = (contentExists(pageData.field_news_author))?pageData.field_news_author: null;
+	const displayDate = (contentExists(pageData.field_publish_date))? pageData.field_publish_date: null;
+	const updatedDate = (contentExists(pageData.changed))? pageData.changed: null;
+	const imageCredit = (contentExists(pageData.field_lead_image))? pageData.field_lead_image: null;
+	const body = (contentExists(pageData.body)) ? pageData.body.processed:``;
+	const bodyInline = InlineImage(body); 
+	const footer = data.footer.edges;
+	const imageData=data.images.edges;
+
+
+
 	return (
 		<Layout>
-			<Seo title={title} keywords={[`gatsby`, `application`, `react`]} />
-			<h1>{title}</h1>
-			<div dangerouslySetInnerHTML={{ __html: body}} />
+			<Seo title={pageTitle} keywords={[`gatsby`, `application`, `react`]} />
+			{/**** Header and Title ****/ }
+			{(imageData?.length > 0) &&
+			<div className={imageData?.length > 0 ? "" : "no-thumb"} id="rotator">
+				<Hero imgData={imageData} />
+
+			</div>}
+			<div className="container page-container">
+                <div className="row site-content">
+                    <div className="content-area">
+						<h1>{pageTitle}</h1>
+						<p>{author && <><strong>By </strong>{author}<br/></>}</p>
+						<div className="row">
+							<div className="col-md-9 col-12 col">
+								<div className ="clearfix">
+									<div>{bodyInline}</div>
+								</div>														
+							</div>
+							<div className="col-md-3 col-12">
+								<p><strong>News Categories</strong></p>
+								{pageData.relationships.field_news_category.map (newsCategory =>{return ListAsButtons(newsCategory.name)} )}
+								<p>
+									{displayDate && <><strong>Posted </strong> {displayDate}</>}<br/>
+									{updatedDate && <><strong>Updated </strong>{updatedDate}</>}<br/>
+									{imageCredit && <><strong>Lead Image </strong>{imageCredit}</>}
+								</p>
+								<p><strong>News Topics</strong></p>
+								{pageData.relationships.field_news_topics.map (newsTopic => { return ListAsButtons(newsTopic.name)})}
+							</div>
+						</div>
+                    </div>
+                </div>
+              </div>
+
+		  	{ /**** Custom Footer content ****/}
+			{footer?.length > 0 &&
+			<CustomFooter footerData={footer[0]} />}
 		</Layout>
 	)
 }
 
-/* export const query = graphql`
-  query ($id: String) {
+export default ArticlePage;
+
+export const query = graphql`
+  query ($id: String, $tid: [String]) {
 	articles: allNodeArticle(filter: {id: {eq: $id}}) {
 		edges {
 			node {
@@ -26,8 +93,40 @@ export default ({data}) => {
 				body {
 					processed
 				}
+				field_news_author
+				field_lead_image
+				field_publish_date (formatString: "MMMM DD, YYYY")
+				changed (formatString: "MMMM DD, YYYY")
+				relationships {
+					field_news_category {
+					  name
+					  relationships {
+						parent {
+						  name
+						}
+					  }
+					}
+					field_news_topics {
+						name
+					}
+				}
 		  	}
 		}
 	}
+	images: allMediaImage(filter: {relationships: {node__article: {elemMatch: {id: {eq: $id}}}}}) {
+		edges {
+		  node {
+			drupal_id
+			...HeroImageFragment
+		  }
+		}
+	  }
+	footer: allNodeCustomFooter (filter: {fields: {tags: {in: $tid}}}){
+		edges {
+			node {
+			...CustomFooterFragment
+			}
+		}
+		}
   }
-` */
+`


### PR DESCRIPTION
# Summary of changes
Displaying News articles - this was just to display the full news article. 

## Frontend
Updated article-page.js 
  - Display of basic content from the News Content Type (used news.uoguelph.ca as layout guide)
Added inlineImage.js file to display inline images from the body field - note: this is done generically so any field that has inline images added the url will be changed from the default google to the build url. 
Updated 
Updated gatsby-node.js
  - added a createNewsContentTypeAlias function to create the news article alias
       - Note when you do a gatsby develop - there will be a console.log of the aliases for the article
  - updating the schema - on hold till initial review to ensure that the tagging method is correct.
  - 

## Backend
See the info on teams - [Multidev Merge Requests](https://teams.microsoft.com/l/message/19:f2ae5b00dc95407d8902b0e04ff98ec1@thread.tacv2/1686924425341?tenantId=be62a12b-2cad-49a1-a5fa-85f4f3156a7d&groupId=cde949b1-e9d8-483b-8d20-e9b8fd9e493d&parentMessageId=1686924425341&teamName=Content%20Hub%20Team&channelName=Multidev%20Merge%20Requests&createdTime=1686924425341&allowXTenantAccess=false) 


# Test Plan

Example page -

To test compare the backend -https://sns-news-chug.pantheonsite.io/ has the same info as the example above. 
Note: the News Categories and News Topics are displayed as buttons with no url attached for testing. When we have pages being created for these they will need to be added. Recommend we do a review at this point, and then add the next steps to this branch and/or mulitdev before they are merged. 

Note some issues with mobile view 

Insert steps. Include URLs of Gatsby Cloud test site and Drupal multidev.

