### PR TITLE
PBI #76851 Fix warning  React Hook useEffect has a missing dependency

### DIFF
--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react"
+import React, { useState, useEffect, useMemo, useRef } from "react"
 import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import Tab from "react-bootstrap/Tab"
@@ -9,7 +9,9 @@ import { slugify, ParseText } from "../../utils/ug-utils"
 
 const PageTabs = (props) => {
   const container = useRef(null)
-  const tabs = props.pageData?.relationships?.field_tabs ?? []
+  const tabs = useMemo(() => {
+    return props.pageData?.relationships?.field_tabs ?? []
+  }, [props.pageData?.relationships?.field_tabs])
   const [activeTab, setActiveTab] = useState(tabs[0]?.drupal_id ?? "")
 
   useEffect(() => {
@@ -29,7 +31,7 @@ const PageTabs = (props) => {
 
       found && container.current?.scrollIntoView({ block: "start", inline: "nearest" })
     }
-  }, [])
+  }, [tabs])
 
   if (tabs.length <= 0) {
     return null

--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import Tab from "react-bootstrap/Tab"
@@ -9,10 +9,8 @@ import { slugify, ParseText } from "../../utils/ug-utils"
 
 const PageTabs = (props) => {
   const container = useRef(null)
-  const tabs = useMemo(() => {
-    return props.pageData?.relationships?.field_tabs ?? []
-  }, [props.pageData?.relationships?.field_tabs])
-  const [activeTab, setActiveTab] = useState(tabs[0]?.drupal_id ?? "")
+  const tabs = props.pageData?.relationships?.field_tabs;
+  const [activeTab, setActiveTab] = useState(tabs?.[0]?.drupal_id ?? "")
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -20,27 +18,27 @@ const PageTabs = (props) => {
 
     if (titleOrID) {
       // Try to find a tab with a matching drupal id
-      let found = tabs.find((tab) => tab.drupal_id === titleOrID)
+      let found = tabs?.find((tab) => tab.drupal_id === titleOrID)
 
       // If we couldn't find a matching id, then try and find a matching title
-      found ??= tabs.find((tab) => titleOrID === slugify(tab.field_tab_title.toLowerCase()))
+      found ??= tabs?.find((tab) => titleOrID === slugify(tab.field_tab_title.toLowerCase()))
 
       // Set the active tab to which ever was found
       // If neither could be found then set the active tab to the first tab.
-      setActiveTab(found?.drupal_id ?? tabs[0]?.drupal_id)
+      setActiveTab(found?.drupal_id ?? tabs?.[0]?.drupal_id)
 
       found && container.current?.scrollIntoView({ block: "start", inline: "nearest" })
     }
   }, [tabs])
 
-  if (tabs.length <= 0) {
+  if (tabs?.length <= 0) {
     return null
   }
 
   return (
     <div className="col-md-12 content-area nav-tabs-container" ref={container}>
       <Tabs activeKey={activeTab} onSelect={(k) => setActiveTab(k)} justify transition={Fade}>
-        {tabs.map((tab) => (
+        {tabs?.map((tab) => (
           <Tab key={tab.drupal_id} eventKey={tab.drupal_id} title={tab.field_tab_title.toUpperCase()}>
             <div data-tab-id={tab.drupal_id}>
               <ParseText textContent={tab.field_tab_body.processed} />


### PR DESCRIPTION
warning  React Hook useEffect has a missing dependency: 'tabs'. Either include it or remove the dependency array react-hooks/exhaustive-deps

# Summary of changes
Memoizes Tabs using useMemo. 
Reference: https://kinsta.com/knowledgebase/react-hook-useeffect-has-a-missing-dependency/ 

## Frontend
List all significant changes to Gatsby code

### Memoize Tabs
const tabs = useMemo(() => {
    return props.pageData?.relationships?.field_tabs ?? []
  }, [props.pageData?.relationships?.field_tabs])

### Added Tabs array in useEffect dependency
  }, [tabs])

[ x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[ x] My changes are responsive and appear as expected on mobile and desktop views.
[ x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan
Run gatsby develop/build on gus
Notice the warning has disappeared

