### PR TITLE
Revert tabs warning fix

### DIFF
--- a/src/components/shared/pageTabs.js
+++ b/src/components/shared/pageTabs.js
@@ -29,7 +29,7 @@ const PageTabs = (props) => {
 
       found && container.current?.scrollIntoView({ block: "start", inline: "nearest" })
     }
-  }, [tabs])
+  }, [])
 
   if (tabs?.length <= 0) {
     return null


### PR DESCRIPTION
# Summary of changes
Tabs are not working on Chrome. Reverting tabs warning fix as temporary hot fix.

## Frontend
Reverting tabs warning fix as temporary hot fix.

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x ] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Run deployment
2. On Netlify, check https://www.uoguelph.ca/programs/msc-phd-in-animal-biosciences-thesisresearch/ in an incognito window and see if there are rehydration errors.