### PR TITLE
fix-error-418

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,8 @@
+import ReactDOM from 'react-dom/client'
+
+export const replaceHydrateFunction = () => {
+  return (element, container) => {
+    const root = ReactDOM.createRoot(container)
+    root.render(element)
+  }
+}


### PR DESCRIPTION
# Summary of changes
Fixes error 418.

## Frontend
Added replaceHydrateFunction to gatsby-browser.js to fix hydration errors like was done on doorknob https://github.com/ccswbs/doorknob/pull/54

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

Insert steps. Include URLs of Netlify test site and Drupal multidev.