### PR TITLE
add back-to-top button

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -21,6 +21,7 @@ const Layout = ({ children, date, menuName }) => (
       <DateModified date={date} />
     </main>
     <div className="be-ix-link-block"></div>
+    <uofg-back-to-top></uofg-back-to-top>
     <uofg-footer></uofg-footer>
   </>
 );


### PR DESCRIPTION
# Summary of changes
Add uofg-back-to-top as part of the default layout. See https://github.com/ccswbs/web-components/pull/20 for the code.

## Frontend
- Modified layout.js to add the back to top button

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to any site that is scrollable.
2. Scroll down the page
3. Ensure the back to top button appears in the bottom right of the screen
4. Click the button
5. Ensure the page is scrolled back to the top of the page.