### PR TITLE
fixed the media description to have consistent layout

### DIFF
--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -120,9 +120,11 @@ function MediaText (props) {
                 break;
                 case "large":
                     wrapperCol = "col-xs-12 border-0 card mb-4";
+                    textColHeight = "h-100";
                 break;
                 default:
                     wrapperCol = "col-sm border-0 card mb-4";
+                    textColHeight = "h-100";
                 break;
             }
         }


### PR DESCRIPTION
# Summary of changes
The changes are made to the description part of the media and text widget for videos to be aligned from the bottom.
## Frontend
Made changes to the default and large mediaSize for video descriptions and buttons to include textColHeight = "h-100";.

[X] My changes are accessible (at minimum WCAG 2.0 Level AA)
[X] My changes are responsive and appear as expected on mobile and desktop views.
[N/A] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan
Check this link to make sure the changes are correct: https://deploy-preview-238--ugconthub.netlify.app/admission/undergraduate/campus/. Check other examples of media & text widget and confirm nothing else breaks as a result of this fix.