### PR TITLE
added contition for no-menu in PN

### DIFF
--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -132,7 +132,7 @@ const PageTemplate = ({data}) => (
         widgets={data.nodePage.relationships.field_widgets}
         heroWidgets={(data.nodePage.relationships?.field_hero_widgets ? [data.nodePage.relationships?.field_hero_widgets] : null)}
         footer={data.footer.edges}
-        menuName={data.nodePage.relationships?.field_primary_navigation?.field_menu_machine_name ?? data.menu?.menu_name}
+        menuName={(data.nodePage.relationships?.field_primary_navigation?.field_menu_machine_name === "no-menu")? null: data.nodePage.relationships?.field_primary_navigation?.field_menu_machine_name ?? data.menu?.menu_name}
         domains={data.nodePage.field_domain_access}
     ></Page>
 )


### PR DESCRIPTION
# Summary of changes
Add Condition in Primary navigation for No Menu (no-menu machine-name) that will force a page to have no menu displayed even if it gets put into a menu.
Made Primary Navigation on Basic Pages to be mandatory
 
## Frontend
Modified file page.js to have a condition for the no-menu in primary navigation 

[X] My changes are accessible (at minimum WCAG 2.0 Level AA)
[X] My changes are responsive and appear as expected on mobile and desktop views.
[X] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

##. Backend
Set the Primary Navigation to mandatory (if pages don't have it when editing it will be required when saved)

Note: when going live a new Term needs to be added to the Taxonomy Primary Navigation
Name : No Menu
Machine-name : no-menu


# Test Plan
Multdev - https://sns-nomenu-chug.pantheonsite.io/

Edit a page and see if Primary Navigation is required

- Create a basic page do not add it to a menu, but add No Menu under the Primary Navigation. 
  - page should be created as normal - but, not have a menu. 
- add page to a menu (either via the page add to menu or via the menu add buttion).
  - page should still not have a menu
- all other pages should have a menu if set.