### PR TITLE
Remove obsolete gatsby-plugin-google-analytics and update Call to Action code

### DIFF
--- a/config/sites/ugconthub.js
+++ b/config/sites/ugconthub.js
@@ -4,7 +4,6 @@ var metaConfig = {
     author: "@uofg",
 	ogImage: "https://www.uoguelph.ca/img/ug-social-thumb.jpg",
 	ogImageAlt: "University of Guelph logo",
-    GAtrackingID: "UA-106745064-4",
     IGuser: "5851379098",
     menus: ["main"],
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -13,7 +13,6 @@ if ((metaConfig === null) || (metaConfig === undefined)) {
     metaConfig['author'] = "Author of site";
     metaConfig['ogImage'] = "",
     metaConfig['ogImageAlt'] = "",
-    metaConfig['GAtrackingID'] = "";
     metaConfig['menus'] = "";
 }
 
@@ -39,12 +38,6 @@ module.exports = {
     `gatsby-plugin-root-import`,
     `gatsby-plugin-sharp`,
     `gatsby-transformer-yaml`,
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: metaConfig['GAtrackingID'],
-      },
-    },
     {
       resolve: `gatsby-plugin-google-tagmanager`,
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "gatsby-graphiql-explorer": "^3.13.1",
         "gatsby-plugin-client-side-redirect": "^1.1.0",
         "gatsby-plugin-gatsby-cloud": "^5.13.1",
-        "gatsby-plugin-google-analytics": "^5.13.1",
         "gatsby-plugin-google-tagmanager": "^5.13.1",
         "gatsby-plugin-image": "^3.13.1",
         "gatsby-plugin-manifest": "^5.13.1",
@@ -11678,24 +11677,6 @@
       "peerDependencies": {
         "gatsby": "^5.0.0-next",
         "webpack": "*"
-      }
-    },
-    "node_modules/gatsby-plugin-google-analytics": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-5.13.1.tgz",
-      "integrity": "sha512-6TzvUPW7CBpfpSIqpcvaRwRKTYgM3CKqSnfyRIY16vlAKYkAtZLXm3PkIbg0+mM+WzY6GRnAoeXqRkXJv0FK9A==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "minimatch": "^3.1.2",
-        "web-vitals": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "react": "^18.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby-plugin-google-tagmanager": {
@@ -34072,16 +34053,6 @@
         "kebab-hash": "^0.1.2",
         "lodash": "^4.17.21",
         "webpack-assets-manifest": "^5.1.0"
-      }
-    },
-    "gatsby-plugin-google-analytics": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-5.13.1.tgz",
-      "integrity": "sha512-6TzvUPW7CBpfpSIqpcvaRwRKTYgM3CKqSnfyRIY16vlAKYkAtZLXm3PkIbg0+mM+WzY6GRnAoeXqRkXJv0FK9A==",
-      "requires": {
-        "@babel/runtime": "^7.20.13",
-        "minimatch": "^3.1.2",
-        "web-vitals": "^1.1.2"
       }
     },
     "gatsby-plugin-google-tagmanager": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "gatsby-graphiql-explorer": "^3.13.1",
     "gatsby-plugin-client-side-redirect": "^1.1.0",
     "gatsby-plugin-gatsby-cloud": "^5.13.1",
-    "gatsby-plugin-google-analytics": "^5.13.1",
     "gatsby-plugin-google-tagmanager": "^5.13.1",
     "gatsby-plugin-image": "^3.13.1",
     "gatsby-plugin-manifest": "^5.13.1",

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -1,107 +1,162 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import { Link } from 'gatsby';
-import { fontAwesomeIconColour } from 'utils/ug-utils';
-import { trackCustomEvent } from 'gatsby-plugin-google-analytics';
-import classNames from 'classnames';
+import PropTypes from "prop-types";
+import React from "react";
+import { Link } from "gatsby";
+import { fontAwesomeIconColour } from "utils/ug-utils";
+//import { trackCustomEvent } from 'gatsby-plugin-google-analytics';
+import classNames from "classnames";
 
 function buttonStyle(styleOfButton) {
-    switch(styleOfButton){
-        case 'Primary':
-            return 'btn-primary';
-        case 'Primary (Outline)':
-            return 'btn-outline-primary';
-        case 'Secondary':
-            return 'btn-secondary';
-        case 'Secondary (Outline)':
-            return 'btn-outline-secondary';
-        case 'Info':
-            return 'btn-info';
-        case 'Info (Outline)':
-            return 'btn-outline-info'
-        case 'Success':
-            return 'btn-success';
-        case 'Success (Outline)':
-            return 'btn-outline-success'
-        case 'Warning':
-            return 'btn-warning';
-        case 'Warning (Outline)':
-            return 'btn-outline-warning'
-        case 'Danger':
-            return 'btn-danger';
-        case 'Danger (Outline)':
-            return 'btn-outline-danger'
-        case 'Light':
-            return 'btn-light';
-        case 'Light (Outline)':
-            return 'btn-outline-light'
-        case 'Dark':
-            return 'btn-dark';
-        case 'Dark (Outline)':
-            return 'btn-outline-dark'
-        default:
-            return 'btn-primary';
-    }
+  switch (styleOfButton) {
+    case "Primary":
+      return "btn-primary";
+    case "Primary (Outline)":
+      return "btn-outline-primary";
+    case "Secondary":
+      return "btn-secondary";
+    case "Secondary (Outline)":
+      return "btn-outline-secondary";
+    case "Info":
+      return "btn-info";
+    case "Info (Outline)":
+      return "btn-outline-info";
+    case "Success":
+      return "btn-success";
+    case "Success (Outline)":
+      return "btn-outline-success";
+    case "Warning":
+      return "btn-warning";
+    case "Warning (Outline)":
+      return "btn-outline-warning";
+    case "Danger":
+      return "btn-danger";
+    case "Danger (Outline)":
+      return "btn-outline-danger";
+    case "Light":
+      return "btn-light";
+    case "Light (Outline)":
+      return "btn-outline-light";
+    case "Dark":
+      return "btn-dark";
+    case "Dark (Outline)":
+      return "btn-outline-dark";
+    default:
+      return "btn-primary";
+  }
 }
 
-function Button (buttonCol, buttonData, buttonSpacing) {
-  
-    let urlLink = buttonData.field_button_link?.url;
-    let buttonLinkTitle = buttonData?.field_formatted_title ? buttonData.field_formatted_title.processed : (buttonData.field_button_link?.title ? buttonData.field_button_link.title : "No title entered");
-    let buttonIcon = buttonData?.field_font_awesome_icon;
-    let buttonIconColour = buttonData.relationships.field_font_awesome_icon_colour?.name;
-    let buttonClasses = classNames('btn', buttonStyle(buttonData.relationships.field_button_style?.name), buttonSpacing, 'no-icon', 'p-4');
-    let buttonFontAwesomeClasses = classNames('align-middle','display-2','pe-3', buttonIcon, (buttonIconColour ? fontAwesomeIconColour(buttonIconColour) : null));
-    let btnAnalyticsGoal = buttonData.relationships.field_cta_analytics_goal?.name;
-    let btnAnalyticsAction = buttonData.relationships.field_cta_analytics_goal?.field_goal_action;
-    let buttonTitleClasses = classNames('align-middle','lh-sm');
+function Button(buttonCol, buttonData, buttonSpacing) {
+  let urlLink = buttonData.field_button_link?.url;
+  let buttonLinkTitle = buttonData?.field_formatted_title
+    ? buttonData.field_formatted_title.processed
+    : buttonData.field_button_link?.title
+      ? buttonData.field_button_link.title
+      : "No title entered";
+  let buttonIcon = buttonData?.field_font_awesome_icon;
+  let buttonIconColour = buttonData.relationships.field_font_awesome_icon_colour?.name;
+  let buttonClasses = classNames(
+    "btn",
+    buttonStyle(buttonData.relationships.field_button_style?.name),
+    buttonSpacing,
+    "no-icon",
+    "p-4"
+  );
+  let buttonFontAwesomeClasses = classNames(
+    "align-middle",
+    "display-2",
+    "pe-3",
+    buttonIcon,
+    buttonIconColour ? fontAwesomeIconColour(buttonIconColour) : null
+  );
+  let btnAnalyticsGoal = buttonData.relationships.field_cta_analytics_goal?.name;
+  let btnAnalyticsAction = buttonData.relationships.field_cta_analytics_goal?.field_goal_action;
+  let buttonTitleClasses = classNames("align-middle", "lh-sm");
 
-    // call to action settings
-    if (buttonCol === "Call to Action") {
-        buttonClasses = classNames(buttonClasses,'text-center');
-        buttonTitleClasses = classNames(buttonTitleClasses,'fs-1', 'py-2',(buttonIcon ? 'pe-5' : 'px-5'));
-        buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses,'ps-5');
-    } else {
-        // default settings
-        buttonClasses = classNames(buttonClasses,'text-start');
-        buttonTitleClasses = classNames(buttonTitleClasses, 'd-table-cell');
-        buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses,'d-table-cell');
-    }
+  // call to action settings
+  if (buttonCol === "Call to Action") {
+    buttonClasses = classNames(buttonClasses, "text-center");
+    buttonTitleClasses = classNames(buttonTitleClasses, "fs-1", "py-2", buttonIcon ? "pe-5" : "px-5");
+    buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses, "ps-5");
+  } else {
+    // default settings
+    buttonClasses = classNames(buttonClasses, "text-start");
+    buttonTitleClasses = classNames(buttonTitleClasses, "d-table-cell");
+    buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses, "d-table-cell");
+  }
 
-    return (
+  return (
     <React.Fragment key={buttonData.drupal_id}>
-    {buttonData.field_cta_heading && <h2 className="h3 text-dark text-center" dangerouslySetInnerHTML={{__html: buttonData.field_cta_heading.processed}} />}    
-    {urlLink && urlLink.includes("http") ? btnAnalyticsGoal && btnAnalyticsAction ? 
-        <a href={urlLink} className={buttonClasses} onClick={e => {trackCustomEvent({category: btnAnalyticsGoal,action: btnAnalyticsAction,})}}>
-            {buttonIcon && <i aria-hidden="true" className={buttonFontAwesomeClasses}> </i>}
-            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{__html: buttonLinkTitle}} />
-        </a>
-        :
-        <a href={urlLink} className={buttonClasses}>
-            {buttonIcon && <i aria-hidden="true" className={buttonFontAwesomeClasses}> </i>}
-            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{__html: buttonLinkTitle}} />
-        </a>
-        :
-        btnAnalyticsGoal && btnAnalyticsAction ? 
-        <Link to={urlLink} className={buttonClasses} onClick={e => {trackCustomEvent({category: btnAnalyticsGoal,action: btnAnalyticsAction,})}}>		
-            {buttonIcon && <i aria-hidden="true" className={buttonFontAwesomeClasses}> </i>}
-            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{__html: buttonLinkTitle}} />
+      {buttonData.field_cta_heading && (
+        <h2
+          className="h3 text-dark text-center"
+          dangerouslySetInnerHTML={{ __html: buttonData.field_cta_heading.processed }}
+        />
+      )}
+      {urlLink && urlLink.includes("http") ? (
+        btnAnalyticsGoal && btnAnalyticsAction ? (
+          <a
+            href={urlLink}
+            className={buttonClasses}
+            onClick={(e) => {
+              window.dataLayer = window.dataLayer || [];
+              window.dataLayer.push({
+                event: "customEvent",
+                category: btnAnalyticsGoal,
+                action: btnAnalyticsAction,
+              });
+            }}
+          >
+            {buttonIcon && (
+              <i aria-hidden="true" className={buttonFontAwesomeClasses}>
+                {" "}
+              </i>
+            )}
+            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
+          </a>
+        ) : (
+          <a href={urlLink} className={buttonClasses}>
+            {buttonIcon && (
+              <i aria-hidden="true" className={buttonFontAwesomeClasses}>
+                {" "}
+              </i>
+            )}
+            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
+          </a>
+        )
+      ) : btnAnalyticsGoal && btnAnalyticsAction ? (
+        <Link
+          to={urlLink}
+          className={buttonClasses}
+          onClick={(e) => {
+            trackCustomEvent({ category: btnAnalyticsGoal, action: btnAnalyticsAction });
+          }}
+        >
+          {buttonIcon && (
+            <i aria-hidden="true" className={buttonFontAwesomeClasses}>
+              {" "}
+            </i>
+          )}
+          <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
         </Link>
-        :
+      ) : (
         <Link to={urlLink} className={buttonClasses}>
-            {buttonIcon && <i aria-hidden="true" className={buttonFontAwesomeClasses}> </i>}
-            <span className={buttonTitleClasses} dangerouslySetInnerHTML={{__html: buttonLinkTitle}} />
-        </Link>        
-    }
-    </React.Fragment>)
+          {buttonIcon && (
+            <i aria-hidden="true" className={buttonFontAwesomeClasses}>
+              {" "}
+            </i>
+          )}
+          <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
+        </Link>
+      )}
+    </React.Fragment>
+  );
 }
 Button.propTypes = {
-    buttonData: PropTypes.object,
-    buttonSpacing:  PropTypes.string, 
-}
+  buttonData: PropTypes.object,
+  buttonSpacing: PropTypes.string,
+};
 
 Button.defaultProps = {
-    buttonData: ``,
-    buttonSpacing: ``,
-}
-export default Button
+  buttonData: ``,
+  buttonSpacing: ``,
+};
+export default Button;

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -126,13 +126,13 @@ function Button(buttonCol, buttonData, buttonSpacing) {
           to={urlLink}
           className={buttonClasses}
           onClick={(e) => {
-              window.dataLayer = window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : [];
-              window.dataLayer.push({
-                event: "customEvent",
-                category: btnAnalyticsGoal,
-                action: btnAnalyticsAction,
-              });
-            }}
+            window.dataLayer = window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : [];
+            window.dataLayer.push({
+              event: "customEvent",
+              category: btnAnalyticsGoal,
+              action: btnAnalyticsAction,
+            });
+          }}
         >
           {buttonIcon && (
             <i aria-hidden="true" className={buttonFontAwesomeClasses}>

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -96,7 +96,7 @@ function Button(buttonCol, buttonData, buttonSpacing) {
             href={urlLink}
             className={buttonClasses}
             onClick={(e) => {
-              window.dataLayer = window.dataLayer || [];
+              window.dataLayer = window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : [];
               window.dataLayer.push({
                 event: "customEvent",
                 category: btnAnalyticsGoal,
@@ -126,8 +126,13 @@ function Button(buttonCol, buttonData, buttonSpacing) {
           to={urlLink}
           className={buttonClasses}
           onClick={(e) => {
-            trackCustomEvent({ category: btnAnalyticsGoal, action: btnAnalyticsAction });
-          }}
+              window.dataLayer = window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : [];
+              window.dataLayer.push({
+                event: "customEvent",
+                category: btnAnalyticsGoal,
+                action: btnAnalyticsAction,
+              });
+            }}
         >
           {buttonIcon && (
             <i aria-hidden="true" className={buttonFontAwesomeClasses}>

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -2,7 +2,6 @@ import PropTypes from "prop-types";
 import React from "react";
 import { Link } from "gatsby";
 import { fontAwesomeIconColour } from "utils/ug-utils";
-//import { trackCustomEvent } from 'gatsby-plugin-google-analytics';
 import classNames from "classnames";
 
 function buttonStyle(styleOfButton) {

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -9,7 +9,7 @@ const CallToAction = ({ children, classes, href, goalEventCategory, goalEventAct
         href={href}
         onClick={(e) => {
           // Track the custom click
-          window.dataLayer = window.dataLayer || [];
+          window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : []
           window.dataLayer.push({
             event: "custom_event",
             category: goalEventCategory,

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -1,42 +1,47 @@
-import PropTypes from 'prop-types'
-import React from 'react';
-import { trackCustomEvent } from 'gatsby-plugin-google-analytics';
+import PropTypes from "prop-types";
+import React from "react";
 
 const CallToAction = ({ children, classes, href, goalEventCategory, goalEventAction }) => {
-    if (goalEventCategory) {
-        return(
-            <a className={classes} href={href} onClick={e => {
-                // Track the custom click
-                trackCustomEvent({
-                  category: goalEventCategory,
-                  action: goalEventAction,
-                })
-              }}>
-                {children}
-            </a>
-        )
-    }
-    return(
-        <a className={classes} href={href}>
-            {children}
-        </a>
-    )
-}
+  if (goalEventCategory) {
+    return (
+      <a
+        className={classes}
+        href={href}
+        onClick={(e) => {
+          // Track the custom click
+          window.dataLayer = window.dataLayer || [];
+          window.dataLayer.push({
+            event: "custom_event",
+            category: goalEventCategory,
+            action: goalEventAction,
+          });
+        }}
+      >
+        {children}
+      </a>
+    );
+  }
+  return (
+    <a className={classes} href={href}>
+      {children}
+    </a>
+  );
+};
 
 CallToAction.propTypes = {
-    children: PropTypes.node.isRequired,
-    classes: PropTypes.string,
-    goalEventAction: PropTypes.string,
-    goalEventCategory: PropTypes.string,
-    href: PropTypes.string,
-}
-  
-CallToAction.defaultProps = {
-    children: ``,
-    classes: "btn btn-primary fs-1 me-4 p-4 w-100",
-    href: "#",
-    goalEventAction: ``,
-    goalEventCategory: ``,
-}
+  children: PropTypes.node.isRequired,
+  classes: PropTypes.string,
+  goalEventAction: PropTypes.string,
+  goalEventCategory: PropTypes.string,
+  href: PropTypes.string,
+};
 
-export default CallToAction
+CallToAction.defaultProps = {
+  children: ``,
+  classes: "btn btn-primary fs-1 me-4 p-4 w-100",
+  href: "#",
+  goalEventAction: ``,
+  goalEventCategory: ``,
+};
+
+export default CallToAction;

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -9,7 +9,7 @@ const CallToAction = ({ children, classes, href, goalEventCategory, goalEventAct
         href={href}
         onClick={(e) => {
           // Track the custom click
-          window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : []
+          window.dataLayer = Array.isArray(window.dataLayer) ? window.dataLayer : [];
           window.dataLayer.push({
             event: "custom_event",
             category: goalEventCategory,


### PR DESCRIPTION
# Summary of changes
Remove the now-obsolete `gatsby-plugin-google-analytics` and update "Call to Action" code to be compatible with Google Tag Manager instead

## Frontend
- Convert custom event code in `callToAction.js`
- Convert custom event code in `button.js`
- Remove `gatsby-plugin-google-analytics` from `gatsby-config.js`
- Delete unneeded Google Analytics tracking ID from `ugconthub.js` config file
- Uninstall `gatsby-plugin-google-analytics`

### Incidental changes
- Run `prettier` on changed component files to clean up formatting (normally the "hide whitespace" option takes care of this on a PR, but for some reason it's not working on this one. As a workaround, go to https://app.semanticdiff.com/ and paste this URL - https://github.com/ccswbs/gus/pull/247/files - to exclude the `prettier` changes)

## Backend
N/A

# Test Plan
- Go to [Google Tag Manager](https://tagmanager.google.com) and log in 
- Run [Preview](https://support.google.com/tagmanager/answer/6107056?hl=en).
- Paste the URL https://gtmfix--vocal-pixie-1d74d4.netlify.app/programs/bachelor-of-arts-general-fully-online/ which will then open in a separate tab
- Return to the Tag Assistant tab and click the `Data Layer` option
- Switch to the https://gtmfix--vocal-pixie-1d74d4.netlify.app/programs/bachelor-of-arts-general-fully-online tab and click the `Apply Now` button
- Switch back to the Tag Assistant tab and verify the `Apply Now` custom event details show up

Repeat the above steps for the https://gtmfix--vocal-pixie-1d74d4.netlify.app/oac/graduate-programs/viewbook/ URL, this time using the `Viewbook` button