### PR TITLE
Link widget - Show two or 3 links as full width if in a 9 column section

### DIFF
--- a/src/components/shared/links.js
+++ b/src/components/shared/links.js
@@ -44,7 +44,7 @@ function ListLink({ title, url }) {
 function Links({ links = [], title, headingLevel, description }) {
   const isGrid = links?.some((item) => item.image);
   const Heading = getHeadingLevel(headingLevel);
-  const numColumns = links.length;
+  const numLinks = links.length;
   // const LinkHeading = title ? getHeadingLevel(headingLevel, 1) : "p";
   const LinksInner = isGrid ? "div" : "ul";
 
@@ -53,7 +53,7 @@ function Links({ links = [], title, headingLevel, description }) {
       {title && <Heading>{title}</Heading>}
       {description && <p>{description}</p>}
 
-      <LinksInner className={`${styles.inner} ${(numColumns < 3) && styles.twoOrLess}`}>
+      <LinksInner className={`${styles.inner} ${(numLinks < 3) && styles.twoOrLess}`}>
         {links.map((link) => {
           const { id, title, url, image } = link;
 

--- a/src/components/shared/links.js
+++ b/src/components/shared/links.js
@@ -53,7 +53,7 @@ function Links({ links = [], title, headingLevel, description }) {
       {title && <Heading>{title}</Heading>}
       {description && <p>{description}</p>}
 
-      <LinksInner className={`${styles.inner} ${(numLinks < 3) && styles.twoOrLess}`}>
+      <LinksInner className={`${styles.inner} ${(numLinks === 2 || numLinks === 3) && styles.twoOrThree}`}>
         {links.map((link) => {
           const { id, title, url, image } = link;
 

--- a/src/components/shared/links.js
+++ b/src/components/shared/links.js
@@ -45,7 +45,6 @@ function Links({ links = [], title, headingLevel, description }) {
   const isGrid = links?.some((item) => item.image);
   const Heading = getHeadingLevel(headingLevel);
   const numLinks = links.length;
-  // const LinkHeading = title ? getHeadingLevel(headingLevel, 1) : "p";
   const LinksInner = isGrid ? "div" : "ul";
 
   return (

--- a/src/components/shared/links.js
+++ b/src/components/shared/links.js
@@ -44,6 +44,7 @@ function ListLink({ title, url }) {
 function Links({ links = [], title, headingLevel, description }) {
   const isGrid = links?.some((item) => item.image);
   const Heading = getHeadingLevel(headingLevel);
+  const numColumns = links.length;
   // const LinkHeading = title ? getHeadingLevel(headingLevel, 1) : "p";
   const LinksInner = isGrid ? "div" : "ul";
 
@@ -52,7 +53,7 @@ function Links({ links = [], title, headingLevel, description }) {
       {title && <Heading>{title}</Heading>}
       {description && <p>{description}</p>}
 
-      <LinksInner className={styles.inner}>
+      <LinksInner className={`${styles.inner} ${(numColumns < 3) && styles.twoOrLess}`}>
         {links.map((link) => {
           const { id, title, url, image } = link;
 

--- a/src/styles/links.module.css
+++ b/src/styles/links.module.css
@@ -60,9 +60,9 @@
 
 @media (min-width: 768px) {
   .outer div.inner {
-    grid-template-columns: repeat(auto-fit, minmax(20%, 1fr));
-  }
-  .outer div.inner.twoOrLess {
     grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
+  :global(.col-md-9) .outer div.inner.twoOrThree {
+    grid-template-columns: repeat(auto-fit, minmax(20%, 1fr));
   }
 }

--- a/src/styles/links.module.css
+++ b/src/styles/links.module.css
@@ -62,4 +62,7 @@
   .outer div.inner {
     grid-template-columns: repeat(auto-fit, minmax(20%, 1fr));
   }
+  .outer div.inner.twoOrLess {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
+  }
 }


### PR DESCRIPTION
# Summary of changes
Show two or 3 links as full width if in a 9 column section

## Frontend
Show two or 3 links as full width if in a 9 column section

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
List all significant changes to the Drupal site (e.g. new fields, content types, modules, etc). If adding new fields, try to include help text to ensure users understand how to use the fields.

# Test Plan

View the following URLs
- Page with links in 9 column section: https://deploy-preview-249--preview-ugconthub.netlify.app/transform-0/
- Full-width pages:
  - https://deploy-preview-249--preview-ugconthub.netlify.app/cbs/about-cbs/teaching-excellence/
  - https://deploy-preview-249--preview-ugconthub.netlify.app/our-communities/
  - https://deploy-preview-249--preview-ugconthub.netlify.app/plant-varieties/