### PR TITLE
Add Accordion Description field

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -500,6 +500,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type paragraph__accordion_section implements Node {
       drupal_id: String
+      field_accordion_description: BodyField
       field_accordion_stay_open: Boolean
       field_accordion_title: String
       field_heading_level: String

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -184,12 +184,6 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       format: String
       summary: String
     }
-    type FieldAccordionBlockText {
-      processed: String
-      value: String
-      format: String
-      summary: String
-    }
     type FieldFormattedTitle {
       processed: String
       value: String
@@ -494,7 +488,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type paragraph__accordion_block implements Node {
       drupal_id: String
-      field_accordion_block_text: FieldAccordionBlockText
+      field_accordion_block_text: BodyField
       field_accordion_title: String
       field_heading_level: String
     }

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -6,7 +6,7 @@ import { slugify, ParseText } from 'utils/ug-utils';
 const Accordion = (props) => {
     let accordionData = props.pageData?.relationships?.field_accordion_block_elements;
     let accordionTitle = props.pageData?.field_accordion_title;
-    let accordionDescription = props.pageData?.field_accordion_description.processed;
+    let accordionDescription = props.pageData?.field_accordion_description?.processed;
     let stayOpen = props.pageData?.field_accordion_stay_open;
     let dataParent = ("#accordion" + props.pageData?.drupal_id);
     let HeadingLevel = (props.pageData?.field_heading_level ? props.pageData.field_heading_level : "h2");

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -6,7 +6,7 @@ import { slugify, ParseText } from 'utils/ug-utils';
 const Accordion = (props) => {
     let accordionData = props.pageData?.relationships?.field_accordion_block_elements;
     let accordionTitle = props.pageData?.field_accordion_title;
-    let accordionDescription = props.pageData?.field_accordion_description;
+    let accordionDescription = props.pageData?.field_accordion_description.processed;
     let stayOpen = props.pageData?.field_accordion_stay_open;
     let dataParent = ("#accordion" + props.pageData?.drupal_id);
     let HeadingLevel = (props.pageData?.field_heading_level ? props.pageData.field_heading_level : "h2");
@@ -14,7 +14,7 @@ const Accordion = (props) => {
     if (accordionData) {
       return (<>
           {accordionTitle && <HeadingLevel id={slugify(accordionTitle)} className="mt-5">{accordionTitle}</HeadingLevel>}
-          {accordionDescription && accordionDescription}
+          {accordionDescription && <ParseText textContent={accordionDescription} />}
           <div className="accordion" id={"accordion" + props.pageData.drupal_id}>
             {accordionData.map((item) => {
               const accordionToggle = (

--- a/src/components/shared/accordion.js
+++ b/src/components/shared/accordion.js
@@ -6,6 +6,7 @@ import { slugify, ParseText } from 'utils/ug-utils';
 const Accordion = (props) => {
     let accordionData = props.pageData?.relationships?.field_accordion_block_elements;
     let accordionTitle = props.pageData?.field_accordion_title;
+    let accordionDescription = props.pageData?.field_accordion_description;
     let stayOpen = props.pageData?.field_accordion_stay_open;
     let dataParent = ("#accordion" + props.pageData?.drupal_id);
     let HeadingLevel = (props.pageData?.field_heading_level ? props.pageData.field_heading_level : "h2");
@@ -13,6 +14,7 @@ const Accordion = (props) => {
     if (accordionData) {
       return (<>
           {accordionTitle && <HeadingLevel id={slugify(accordionTitle)} className="mt-5">{accordionTitle}</HeadingLevel>}
+          {accordionDescription && accordionDescription}
           <div className="accordion" id={"accordion" + props.pageData.drupal_id}>
             {accordionData.map((item) => {
               const accordionToggle = (
@@ -60,6 +62,9 @@ export default Accordion
 export const query = graphql`
   fragment AccordionSectionParagraphFragment on paragraph__accordion_section {
     drupal_id
+    field_accordion_description {
+      processed
+    }
     field_accordion_stay_open
     field_accordion_title
     field_heading_level


### PR DESCRIPTION
# Summary of changes
Add new field `Accordion Description` for optional intro/explanation of Accordion items

## Frontend
- Add `Accordion Description` field to `accordion.js`
- Add `Accordion Description` field to schema in `gatsby-node.js`

### Incidental changes
- Remove `FieldAccordionBlockText` from schema and use `BodyField` instead (since they're identical aside from name)

[ x ] My changes are accessible (at minimum WCAG 2.0 Level AA)
[ x ] My changes are responsive and appear as expected on mobile and desktop views.
[ x ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
 - Add new long text field `Accordion Description` to Accordion widget

# Test Plan
Multidev URL: https://tq-acctext-chug.pantheonsite.io
Netlify build: https://vocal-pixie-1d74d4.netlify.app/

- Go to https://vocal-pixie-1d74d4.netlify.app/indigenous-initiatives/indigenous-identity-confirmation-students/ and ensure the  text displays beneath *Confirmation Process* heading
- Go to https://deploy-preview-251--ugconthub.netlify.app/admission/undergraduate/requirements/canadian/ and ensure regular accordions work as expected
- Go to https://tq-acctext-chug.pantheonsite.io/node/3800/edit and add an Accordion widget. Fill in the new *Accordion Description* field then [run a Netlify build](https://app.netlify.com/sites/vocal-pixie-1d74d4/deploys) and ensure the content shows up