### PR TITLE
Render header when menu is empty

### DIFF
--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -84,10 +84,12 @@ const generateMenu = (menuLinks, menuName) => {
 
   return (
     <>
-      {pageHome && pageHome.title != null && (
+      {pageHome && pageHome.title != null ? (
         <uofg-header page-title={pageHome.title} page-url={pageHome.link.url}>
           {menuItems}
         </uofg-header>
+      ) : (
+        <uofg-header></uofg-header>
       )}
     </>
   );


### PR DESCRIPTION
# Summary of changes
Currently if a page has a menu and that menu is empty, the header will not render on the page. So I've added a check to see if the menu is empty and still render a header, as if there was no menu.

## Frontend
- Modified check for empty menu to emit header in headerMenu.js

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to a page with an empty menu (ex. https://66fec34bfe8a2d00085da7f8--preview-ugconthub.netlify.app/ridgetown/agriculture-diploma/) and see that the header does not render
2. Go to the same page on the deploy preview (ex. https://deploy-preview-252--preview-ugconthub.netlify.app/ridgetown/agriculture-diploma/) and ensure the header does render
3. Check other pages to ensure the header works as expected.