### PR TITLE
Create all redirects (not just alias-affiliated redirects)

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1125,7 +1125,8 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         const node = destinationPath.replace(/\D/g, "");
         const alias = aliases[node] ?? destinationPath;
 
-        if (sourcePath.toLowerCase() !== alias.toLowerCase()) {
+        // Skip if sourcePath and alias are the same except for letter case
+        if (sourcePath.toLowerCase() !== alias) {
           createRedirect({
             fromPath: sourcePath,
             toPath: alias,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1017,17 +1017,14 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
   `).then((result) => {
     const data = [];
     if (!result.errors) {
-
       result.data.allRedirectRedirect.edges.forEach(({ node }) => {
         const redirect_uri = node.redirect_redirect.uri.replace(/^entity:|internal:\//, "/");
-
         if (!(redirect_uri in data)) {
           data[redirect_uri] = [];
         }
         data[redirect_uri].push(node);
       });
     }
-
     return data;
   });
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1122,8 +1122,9 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
       values.forEach((redirect) => {
         const sourcePath = "/" + redirect.redirect_source.path;
         const destinationPath = redirect.redirect_redirect.uri.replace(/^entity:|internal:\//, "/");
-        const node = destinationPath.replace(/\D/g, "");
-        const alias = aliases[node] ?? destinationPath;
+        // retrieve node ID from destinationPath by replacing all characters that are not digits
+        const nodeID = destinationPath.replace(/\D/g, "");
+        const alias = aliases[nodeID] ?? destinationPath;
 
         // Skip if sourcePath and alias are the same except for letter case
         if (sourcePath.toLowerCase() !== alias) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1018,23 +1018,16 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
     const data = [];
     if (!result.errors) {
 
-      // for each redirect
       result.data.allRedirectRedirect.edges.forEach(({ node }) => {
-        //replace the entity: or internal: with a slash
         const redirect_uri = node.redirect_redirect.uri.replace(/^entity:|internal:\//, "/");
 
-        // if redirect_uri does not exist in data, create a new array
         if (!(redirect_uri in data)) {
           data[redirect_uri] = [];
         }
-
-        // push the redirect node onto the array using redirect_uri as a key
-        // means a redirect_uri may have multiple redirects associated with it
         data[redirect_uri].push(node);
       });
     }
 
-    // return all redirects (should still have all redirects in there)
     return data;
   });
 
@@ -1088,6 +1081,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
     // INSTRUCTION: Create a page for each node by processing the results of your query here
     // Each content type should have its own if statement code snippet
 
+    // ALIASES will contain all url aliases for pages and programs that are NOT archived
     let aliases = {};
 
     // process page nodes
@@ -1124,10 +1118,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
       });
     }
 
-    // ALIASES contains all url aliases for pages and programs that are not archived
-
-    // REDIRECTS
-
+    // REDIRECTS contains all redirects that point to a specific redirect_uri (key)
     Object.entries(redirects).forEach(([key,values]) => {
 
       // create each redirect affiliated with the node
@@ -1136,9 +1127,6 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
         const destinationPath = redirect.redirect_redirect.uri.replace(/^entity:|internal:\//, "/");
         const node = destinationPath.replace(/\D/g, "");
         const alias = aliases[node] ?? destinationPath;
-
-        console.log("From sourcePath:" + sourcePath);
-        console.log("To destinationAlias:" + alias);
 
         if (sourcePath.toLowerCase() !== alias.toLowerCase()) {
           createRedirect({


### PR DESCRIPTION
# Summary of changes
Currently, our code does not create redirects in cases where the destination URL is archived, deleted, or affiliated with an external URL.

The logic is now changed to:
- loop through the redirects data rather than the aliases data
- create ALL redirects in the redirects table, including external URLs. The only exception is if the destination path is not an external URL and does not exist in the aliases table (e.g., if page was archived or deleted).
- keep the existing fix that stops redirects from being created if they point to themselves or if the only difference is case (e.g., uppercase, lowercase, camelCase)

In other words:
- If the redirect exist in the Redirects data:
  -  If the sourcePath is affiliated with an archived page, the redirect **is** created (e.g., /maplewoods to https://www.maplewoods.ca will be created even if the source URL page is archived or deleted).
  - If the destinationPath is affiliated with an archived page, the redirect is **NOT** created (e.g., if someone tries to create a redirect from /some-url to /maplewoods, this will NOT be created unless they make it an absolute link)

---
## Frontend Changes
- Update loop to traverse the redirect data instead of aliases data
- If destination is not external, retrieve url alias from aliases data (if the alias does not exist in that data, alias will have no value and therefore not be created)
- If alias does not exist, do not create a redirect
- Change name of `source_uri` variable to `redirect_uri` for clarity (contents were already the redirect_uri)
- Added comments

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.
- Going forward, if users want to redirect a published page, they can create the redirect, but it will not start working until they archive the page (In Gatsby, the created page always trumps the redirect)

## Backend
- None

---
# General Testing Plan
- Top Priority: On production, ensure the redirects work as expected
- Visit https://api.liveugconthub.uoguelph.dev/admin/config/search/redirect for a full list of redirects
- Find a redirect in the redirects table to test (test to your heart's desire)
- **Production:** https://mmafe-dev.netlify.app has a cleared cache version of published content.
  - (Optional) You can also check at the Deployment PR Published URL: https://deploy-preview-253--ugconthub.netlify.app/ however, I've noticed that it has a caching issue because (even though the alias shows in the redirects table, it keeps redirecting to a /node URL). When I cleared the cache on my mmafse-dev environment, it started processing the correct URL, so...caching.
- **Preview:** Check if it works at the Preview URL: https://deploy-preview-253--preview-ugconthub.netlify.app/

## Published Destination (External)
- Visit https://deploy-preview-253--preview-ugconthub.netlify.app/maplewoods and it should redirect to www.maplewoods.ca
- Visit https://deploy-preview-253--ugconthub.netlify.app/maplewoods and it should redirect to www.maplewoods.ca

## Published Destination (Internal)
- /earth-observation-and-geographic-information-science-co-op-student-information**
  - **Preview:** Visit https://deploy-preview-253--preview-ugconthub.netlify.app/earth-observation-and-geographic-information-science-co-op-student-information and confirm it redirects to https://deploy-preview-253--preview-ugconthub.netlify.app/experiential-learning/future-students/co-op-programs/earth-observation-and-geographic-information-science/
  - **Live:** Visit https://mmafe-dev.netlify.app/earth-observation-and-geographic-information-science-co-op-student-information
    - it should redirect to https://mmafe-dev.netlify.app/experiential-learning/future-students/co-op-programs/earth-observation-and-geographic-information-science/
    - You can see the /node caching issue mentioned above if you visit the PR Production deployment at https://deploy-preview-253--ugconthub.netlify.app/earth-observation-and-geographic-information-science-co-op-student-information which redirects to /node/3912 (even though if you check the redirect table it shows the correct alias). I believe this is a caching issue.
- /application-forms
  - **Preview:** Visit https://deploy-preview-253--preview-ugconthub.netlify.app/application-forms
  - **Live:** Visit https://deploy-preview-253--ugconthub.netlify.app/application-forms

## Unpublished Destination
- /ors
   - **Live:** Visit https://deploy-preview-253--ugconthub.netlify.app/ors or https://mmafe-dev.netlify.app/ors and both **should 404**
   - ** Preview:** Visit https://deploy-preview-253--preview-ugconthub.netlify.app/ors and that SHOULD WORK because the destination is available on Preview
   
- /programs/dairy-apprenticeship
  - **Live:** Visit https://deploy-preview-253--ugconthub.netlify.app/programs/dairy-apprenticeship or https://mmafe-dev.netlify.app/programs/dairy-apprenticeship goes to 404 because its destination is not published
  - **Preview:** Visit https://deploy-preview-253--preview-ugconthub.netlify.app/programs/dairy-apprenticeship goes to /ridgetown/dairy-apprenticeship/ because its destination is visible on the preview site as a draft

---
# Further Information about How Redirects Work
## Example of a Redirect Workflow
- Let's say previously, someone created a redirect from /some-url to /maplewoods.
  - This first redirect will exist as long as the destination URL exists
- When the destination URL /maplewoods gets archived, someone creates a redirect from /maplewoods to https://www.maplewoods.ca
  - This second redirect will exist because sourcePath is always created
- BUT the pre-existing redirect from /some-url to /maplewoods will **break** because the destinationPath is no longer existing. This means, in order to keep that redirect, one would have to update the redirects table to redirect /some-url to an absolute URL https://www.uoguelph.ca/maplewoods (or even better directly to https://www.maplewoods.ca).

[DEV NOTE: I considered the idea of trying to always create the destination URL, even if it did not exist in the aliases table. The idea was to just grab the path and turn it into an absolute URL by adding https://www.uoguelph.ca to the front. The issue is that the sourcePath is a path alias, whereas the destinationPath is a **node ID** in this situation. If the destinationPath node has been deleted, there is no way to look up what node alias was associated with the deleted node ID)

## How do we delete pages then and not break pre-existing redirects?
- When deleting a page, search the redirects table for any redirects that have the deleted path as their destination.
- Provide this list to the client
- If they want to keep these redirects, change them to have absolute URLs as their destination.
- Then the redirect will be created

## Re: Published vs Unpublished
All redirects data is available to both unpublished and published data.
So a redirect may work on Preview, but not on Production, depending on whether the destination page exists or not. (So if a page is unpublished and it is the destination, the redirect will only work on Preview)

## Remember that Pages always Trump Redirects
**Caveat:** If a page is created by Gatsby, a redirect from that page will **NOT** work until the page is no longer being created. So if /maplewoods was still published, the redirect from /maplewoods to another URL will not work until the /maplewoods page is archived, deleted, or unpublished in some way.