### PR TITLE
Change the links for Admissions, Tours, Info in program template

### DIFF
--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -79,7 +79,7 @@ function renderAdmissionRequirements() {
               journey today!
             </p>
             <p>
-              <a href="https://admission.uoguelph.ca/adminfo">View Admission Requirements</a>
+              <a href="https://www.uoguelph.ca/admission/undergraduate/">View Admission Requirements</a>
             </p>
           </div>
         </div>
@@ -107,7 +107,7 @@ function renderAdmissionRequirements() {
               Guelph campus.
             </p>
             <p>
-              <a href="https://admission.uoguelph.ca/tours">Book a Tour</a>
+              <a href="https://www.uoguelph.ca/admission/undergraduate/tours/">Book a Tour</a>
             </p>
           </div>
         </div>
@@ -120,7 +120,7 @@ function renderAdmissionRequirements() {
               of Guelph.
             </p>
             <p>
-              <a href="https://admission.uoguelph.ca/contact">Request More Info</a>
+              <a href="https://www.uoguelph.ca/admission/undergraduate/contact/">Request More Info</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
# Summary of changes
I updated the links on the program page template for the buttons "View Admission Requirements", "Book a Tour" and "Request more Info".

## Frontend
View Admission Requirements takes you to: https://www.uoguelph.ca/admission/undergraduate/
Book a Tour takes you to: https://www.uoguelph.ca/admission/undergraduate/tours/
Request More Info takes you to: https://www.uoguelph.ca/admission/undergraduate/contact/

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

Check to see if:
1. View Admissions Requirement takes you to: https://www.uoguelph.ca/admission/undergraduate/
2. Book a Tour takes you to: https://www.uoguelph.ca/admission/undergraduate/tours/
3. Request More Info takes you to: https://www.uoguelph.ca/admission/undergraduate/contact/