### PR TITLE
Pass region to media text in widget blocks

### DIFF
--- a/src/components/shared/blockWidget.js
+++ b/src/components/shared/blockWidget.js
@@ -17,6 +17,7 @@ const BlockWidget = (props) => {
     }
     if (props.blockData?.relationships?.field_custom_block?.__typename === "block_content__widget_block") {
         widgetBlockContent = props.blockData.relationships.field_custom_block?.relationships?.field_widget_block_content;
+        let widgetRegion = props.blockData.relationships.field_section_column?.name;
         return (widgetBlockContent.map(widget => {
             switch(widget.__typename) {
                 case "paragraph__accordion_section":
@@ -24,7 +25,7 @@ const BlockWidget = (props) => {
                 case "paragraph__general_text":
                     return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;
                 case "paragraph__media_text":
-                    return <MediaText key={widget.drupal_id} widgetData={widget} />;
+                    return <MediaText key={widget.drupal_id} widgetData={widget} region={widgetRegion} />;
                 case "paragraph__section_tabs":
                     return <PageTabs key={widget.drupal_id} pageData={widget} />;
                 case "paragraph__section_buttons":

--- a/src/components/shared/blockWidget.js
+++ b/src/components/shared/blockWidget.js
@@ -17,7 +17,7 @@ const BlockWidget = (props) => {
     }
     if (props.blockData?.relationships?.field_custom_block?.__typename === "block_content__widget_block") {
         widgetBlockContent = props.blockData.relationships.field_custom_block?.relationships?.field_widget_block_content;
-        let widgetRegion = props.blockData.relationships.field_section_column?.name;
+        let widgetRegion = props.blockData.relationships.field_section_column?.name ?? ``;
         return (widgetBlockContent.map(widget => {
             switch(widget.__typename) {
                 case "paragraph__accordion_section":


### PR DESCRIPTION
# Summary of changes
If you add a block with a media text widget to a section, it does not behave as most media text widgets do. This appears to be because it does not pass the section region (if it exists) through to the media text widget.

## Frontend
- Pass the section region (if it exists) to the media text widget, otherwise pass an empty string

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan
1. In the Preview deployment environment, review [PR deployment - Linda's Test Page](https://deploy-preview-255--preview-ugconthub.netlify.app/lindas-test-page/) and compare it to the [Preview - Linda's Test Page](https://preview-ugconthub.netlify.app/lindas-test-page/) to ensure the two blocks (one with 3 media items and one with 2 media items) is appearing as expected
2. Check blocks in other places (nested blocks, blocks in secondary and primary regions, blocks in sections) to confirm they all appear as expected.