### PR TITLE
Allow block widgets to have no section region selected

### DIFF
--- a/src/components/shared/blockWidget.js
+++ b/src/components/shared/blockWidget.js
@@ -17,7 +17,8 @@ const BlockWidget = (props) => {
     }
     if (props.blockData?.relationships?.field_custom_block?.__typename === "block_content__widget_block") {
         widgetBlockContent = props.blockData.relationships.field_custom_block?.relationships?.field_widget_block_content;
-        let widgetRegion = props.blockData.relationships.field_section_column?.name ?? ``;
+        let widgetRegion = props.region;
+
         return (widgetBlockContent.map(widget => {
             switch(widget.__typename) {
                 case "paragraph__accordion_section":
@@ -40,10 +41,12 @@ const BlockWidget = (props) => {
 
 BlockWidget.propTypes = {
     blockData: PropTypes.object,
+    region: PropTypes.string,
 }
 
 BlockWidget.defaultProps = {
     blockData: ``,
+    region: ``,
 }
 
 export default BlockWidget

--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -27,7 +27,7 @@ function renderPrimary(widget) {
     case "paragraph__accordion_section":
       return <Accordion key={widget.drupal_id} pageData={widget} />;
     case "paragraph__block_widget":
-      return <BlockWidget key={widget.drupal_id} blockData={widget} />;
+      return <BlockWidget key={widget.drupal_id} blockData={widget} region="Primary" />;
     case "paragraph__general_text":
       return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;
     case "paragraph__image_overlay":
@@ -58,7 +58,7 @@ function renderPrimary(widget) {
 function renderSecondary(widget, sectionClasses) {
   switch (widget?.__typename) {
     case "paragraph__block_widget":
-      return <BlockWidget key={widget.drupal_id} blockData={widget} />;
+      return <BlockWidget key={widget.drupal_id} blockData={widget} region="Secondary"  />;
     case "paragraph__general_text":
       return <GeneralText key={widget.drupal_id} processed={widget.field_general_text.processed} />;
     case "paragraph__media_text":

--- a/src/components/shared/widget.js
+++ b/src/components/shared/widget.js
@@ -23,7 +23,7 @@ const WidgetSelector = ({ widget }) => {
     case "paragraph__accordion_section":
       return <Accordion pageData={widget} />;
     case "paragraph__block_widget":
-      return <BlockWidget blockData={widget} />;
+      return <BlockWidget key={widget.drupal_id} blockData={widget} />;
     case "paragraph__general_text":
       return <GeneralText processed={widget.field_general_text.processed} />;
     case "paragraph__image_overlay":


### PR DESCRIPTION
# Summary of changes
Currently widget blocks are getting their region from the widget block data. However, for media & text widgets, we need to allow widget blocks to have a null region (in the case where they are not placed in a section).

## Frontend
Allow block widgets to have no section region selected

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. View [/test-page-linda-marciniak/](https://deploy-preview-256--preview-ugconthub.netlify.app/test-page-linda-marciniak/) to see if block appears as expected
2. View https://deploy-preview-256--preview-ugconthub.netlify.app/programs/accounting/ to show how it would appear in a section
3. 