### PR TITLE
Test Page perf

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -12,6 +12,7 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       key="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap"
       rel="stylesheet"
     />,
+    <link rel="preload" href={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`} as="style" />,
     <link
       rel="stylesheet"
       href={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`}
@@ -22,6 +23,7 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       src={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`}
       key={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`}
     ></script>,
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/@uoguelph/uofg-styles/dist/index.css" as="style" />,
     <link
       key="https://cdn.jsdelivr.net/npm/@uoguelph/uofg-styles/dist/index.css"
       rel="stylesheet"

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -18,6 +18,7 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       href={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`}
       key={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.css`}
     />,
+    <link href={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`} rel="preload" as="script" />,
     <script
       type="module"
       src={`${CDN_BASE}/${UOFG_WEB_COMPONENTS_BASE}/uofg-web-components.esm.js`}

--- a/src/components/shared/hero.js
+++ b/src/components/shared/hero.js
@@ -14,7 +14,7 @@ function Hero(props) {
             let altText = img.node.field_media_image.alt;
             return heroImage ? (
               <React.Fragment key={img.node.drupal_id}>
-                <GatsbyImage image={heroImage.gatsbyImage} alt={altText} className="w-100" />
+                <GatsbyImage image={heroImage.gatsbyImage} alt={altText} className="w-100" loading="eager" />
               </React.Fragment>
             ) : null;
           })}


### PR DESCRIPTION
# Summary of changes
-  Add pre-loading for scripts and css in the header
- Eager loading for hero image

## Frontend
Updated gatsby-ssr.js to preload certain resources
Update hero component for eager loading

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend

# Test Plan

Check https://deploy-preview-267--preview-ugconthub.netlify.app/programs/bachelor-of-mathematics/
on Page Speed tool, vs existing live page. Should see some improvement in the overall times.

