### PR TITLE
Change text before Apply Now button to Get Future Ready

### DIFF
--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -358,7 +358,7 @@ const ProgramPage = ({ data, location }) => {
         <div className="container page-container apply-footer">
           <section className="row row-with-vspace site-content">
             <div className="col-sm-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4 content-area">
-              <h3 className="text-dark text-center">Are you ready to Improve Life?</h3>
+              <h3 className="text-dark text-center">Get Future Ready</h3>
               {callToActionData.map((cta, index) => (
                 <CallToAction
                   key={index}


### PR DESCRIPTION
# Summary of changes
I just changed the text that appears before the Apply Now button from "Are you ready to Improve Life?" to "Get Future Ready" on the Program templates.

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[N/A ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

Check to see if this change appears on this specific program pages:

https://www.uoguelph.ca/programs/bachelor-of-applied-science/ 
https://www.uoguelph.ca/programs/bachelor-of-arts/
https://www.uoguelph.ca/programs/bachelor-of-arts-and-sciences/
https://www.uoguelph.ca/programs/bachelor-of-bio-resource-management/
https://www.uoguelph.ca/programs/bachelor-of-commerce/ *
https://www.uoguelph.ca/programs/bachelor-of-computing/
https://www.uoguelph.ca/programs/bachelor-of-engineering/
https://www.uoguelph.ca/programs/bachelor-of-one-health/
https://www.uoguelph.ca/programs/bachelor-of-science/
https://www.uoguelph.ca/programs/bachelor-of-science-in-agriculture/
https://www.uoguelph.ca/programs/bachelor-of-science-in-environmental-sciences/
