### PR TITLE
Use single menu hook instead of two static queries

### DIFF
--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -1,7 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Link, StaticQuery, graphql } from 'gatsby';
-import 'styles/breadcrumbs.css';
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link, StaticQuery, graphql } from 'gatsby'
+import 'styles/breadcrumbs.css'
+import { useMenuData } from "../../hooks/drupal/use-menu-data"
 
 /***
 * Recursive function to iterate through the menu in search of parents
@@ -119,33 +120,10 @@ const makeBreadcrumbTrail = (menuData, domains, menuName, nodeID, nodeTitle) => 
     return null;
 }
 
-const Breadcrumbs = (props) => (
-   <StaticQuery
-      query={
-        graphql`query BreadcrumbMenuQuery {
-  allMenuLinkContentMenuLinkContent(
-    sort: {weight: ASC}
-    filter: {enabled: {eq: true}}
-  ) {
-    edges {
-      node {
-        drupal_id
-        drupal_parent_menu_item
-        menu_name
-        link {
-          uri
-          url
-        }
-        title
-        weight
-      }
-    }
+const Breadcrumbs = (props) => {
+    const data = useMenuData();
+    return makeBreadcrumbTrail(data, props.domains, props.menuName, props.nodeID, props.nodeTitle)
   }
-}`
-      }
-      render={data => makeBreadcrumbTrail(data, props.domains, props.menuName, props.nodeID, props.nodeTitle)}
-   />
-)
 
 Breadcrumbs.propTypes = {
     domains: PropTypes.array,

--- a/src/components/shared/breadcrumbs.js
+++ b/src/components/shared/breadcrumbs.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link, StaticQuery, graphql } from 'gatsby'
+import { Link } from 'gatsby'
 import 'styles/breadcrumbs.css'
-import { useMenuData } from "../../hooks/drupal/use-menu-data"
+import { useMenuData } from "hooks/drupal/use-menu-data"
 
 /***
 * Recursive function to iterate through the menu in search of parents

--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -3,8 +3,8 @@
  * https://github.com/xaviemirmon/gatsby-plugin-drupal-menus
  ***/
 import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
 import PropTypes from "prop-types"
+import { useMenuData } from "../../hooks/drupal/use-menu_data"
 
 const createMenuHierarchy = (menuData, menuName) => {
   let tree = [],
@@ -96,31 +96,8 @@ const generateMenu = (menuLinks, menuName) => {
 };
 
 const HeaderMenu = ({ menuName }) => {
-  const data = useStaticQuery(graphql`
-    query HeaderMenuQuery {
-      allMenuLinkContentMenuLinkContent(sort: { weight: ASC }) {
-        edges {
-          node {
-            enabled
-            title
-            expanded
-            external
-            langcode
-            weight
-            link {
-              uri
-              url
-            }
-            drupal_parent_menu_item
-            bundle
-            drupal_id
-            menu_name
-          }
-        }
-      }
-    }
-  `)
-   return generateMenu(data, menuName)
+  const data = useMenuData();
+  return generateMenu(data, menuName)
 }
 
 HeaderMenu.propTypes = {

--- a/src/components/shared/headerMenu.js
+++ b/src/components/shared/headerMenu.js
@@ -4,7 +4,7 @@
  ***/
 import React from "react"
 import PropTypes from "prop-types"
-import { useMenuData } from "../../hooks/drupal/use-menu_data"
+import { useMenuData } from "hooks/drupal/use-menu-data"
 
 const createMenuHierarchy = (menuData, menuName) => {
   let tree = [],

--- a/src/hooks/drupal/use-menu-data.js
+++ b/src/hooks/drupal/use-menu-data.js
@@ -1,0 +1,32 @@
+import { useStaticQuery, graphql } from "gatsby";
+
+export const useMenuData = () => {
+  const menuData = useStaticQuery(graphql`
+    query HeaderMenuQuery {
+      allMenuLinkContentMenuLinkContent(
+        sort: {weight: ASC}
+        filter: {enabled: {eq: true}}) {
+          edges {
+            node {
+              bundle
+              drupal_id
+              drupal_parent_menu_item
+              enabled
+              expanded
+              external
+              langcode
+              link {
+                uri
+                url
+              }
+              menu_name
+              title
+              weight
+            }
+          }
+      }
+    }
+  `);
+
+  return menuData;
+};


### PR DESCRIPTION
# Summary of changes
Use menu hook instead of two static queries

## Frontend
Use menu hook instead of two static queries

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan
1. Review any page
2. Check through the Networking tab and confirm if the menu graphql results are shown once or twice (should be once now)