### PR TITLE
add outline for 1 of 2 buttons

### DIFF
--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -40,7 +40,7 @@ CallToAction.propTypes = {
 
 CallToAction.defaultProps = {
   children: ``,
-  classes: "btn fs-1 me-lg-4 me-md-4 p-4 w-sm-100 w-md-100 w-50",
+  classes: "btn fs-1 me-lg-4 me-md-4 p-4 w-sm-100 w-md-100 w-lg-50",
   href: "#",
   goalEventAction: ``,
   goalEventCategory: ``,

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -3,7 +3,7 @@ import React from "react";
 import classNames from "classnames";
 
 const CallToAction = ({ children, btnClass, classes, href, goalEventCategory, goalEventAction }) => {
-  let className = classNames(btnClass,'btn fs-1 me-4 p-4 w-100');
+  let className = classNames(btnClass,classes);
   if (goalEventCategory) {    
     return (
       <a
@@ -38,7 +38,6 @@ CallToAction.propTypes = {
   href: PropTypes.string,
 };
 
-/* will remove the default classes if className works as expected */ 
 CallToAction.defaultProps = {
   children: ``,
   classes: "btn btn-primary fs-1 me-4 p-4 w-100",

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -40,7 +40,7 @@ CallToAction.propTypes = {
 
 CallToAction.defaultProps = {
   children: ``,
-  classes: "btn btn-primary fs-1 me-4 p-4 w-100",
+  classes: "btn fs-1 me-4 p-4 w-100",
   href: "#",
   goalEventAction: ``,
   goalEventCategory: ``,

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -1,11 +1,13 @@
 import PropTypes from "prop-types";
 import React from "react";
+import classNames from "classnames";
 
-const CallToAction = ({ children, classes, href, goalEventCategory, goalEventAction }) => {
-  if (goalEventCategory) {
+const CallToAction = ({ children, btnClass, classes, href, goalEventCategory, goalEventAction }) => {
+  let className = classNames(btnClass,'btn fs-1 me-4 p-4 w-100');
+  if (goalEventCategory) {    
     return (
       <a
-        className={classes}
+        className = {className}
         href={href}
         onClick={(e) => {
           // Track the custom click
@@ -22,7 +24,7 @@ const CallToAction = ({ children, classes, href, goalEventCategory, goalEventAct
     );
   }
   return (
-    <a className={classes} href={href}>
+    <a className={className} href={href}>
       {children}
     </a>
   );
@@ -36,6 +38,7 @@ CallToAction.propTypes = {
   href: PropTypes.string,
 };
 
+/* will remove the default classes if className works as expected */ 
 CallToAction.defaultProps = {
   children: ``,
   classes: "btn btn-primary fs-1 me-4 p-4 w-100",

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -40,7 +40,7 @@ CallToAction.propTypes = {
 
 CallToAction.defaultProps = {
   children: ``,
-  classes: "btn fs-1 me-lg-4 me-md-4 p-4 w-sm-100 w-md-100 w-lg-50",
+  classes: "btn fs-1 p-4 w-100",
   href: "#",
   goalEventAction: ``,
   goalEventCategory: ``,

--- a/src/components/shared/callToAction.js
+++ b/src/components/shared/callToAction.js
@@ -40,7 +40,7 @@ CallToAction.propTypes = {
 
 CallToAction.defaultProps = {
   children: ``,
-  classes: "btn fs-1 me-4 p-4 w-100",
+  classes: "btn fs-1 me-lg-4 me-md-4 p-4 w-sm-100 w-md-100 w-50",
   href: "#",
   goalEventAction: ``,
   goalEventCategory: ``,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -228,7 +228,17 @@ i.green {
 @media (max-width: 768px) {
   .ug-slate .form_button_submit {
     width: 100%;
-  }
+  } 
+  
+  .w-sm-100 {
+    width: 100% !important;
+    }
+}
+
+@media (max-width: 1024px) {
+  .w-md-100 {
+    width: 100% !important;
+    }
 }
 
 @media (min-width: 992px) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -228,14 +228,13 @@ i.green {
 @media (max-width: 768px) {
   .ug-slate .form_button_submit {
     width: 100%;
-  } 
-  
+  }
   .w-sm-100 {
     width: 100% !important;
     }
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 991px) {
   .w-md-100 {
     width: 100% !important;
     }
@@ -247,6 +246,9 @@ i.green {
   }
   .ug-slate .form_button_submit {
     font-size: 2.5rem !important;
+  }
+  .w-lg-50 {
+    width: 50% !important;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -229,15 +229,6 @@ i.green {
   .ug-slate .form_button_submit {
     width: 100%;
   }
-  .w-sm-100 {
-    width: 100% !important;
-    }
-}
-
-@media (max-width: 991px) {
-  .w-md-100 {
-    width: 100% !important;
-    }
 }
 
 @media (min-width: 992px) {
@@ -246,9 +237,6 @@ i.green {
   }
   .ug-slate .form_button_submit {
     font-size: 2.5rem !important;
-  }
-  .w-lg-50 {
-    width: 50% !important;
   }
 }
 

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -70,10 +70,10 @@ function renderTalkToStudent() {
 function renderAdmissionRequirements() {
   return (
     <>
-      <div class="row row-cols-1 row-cols-sm-2 my-5">
-        <div class="card border-0 mb-4 col">
-          <div class="card-body p-4 uog-blue-muted uog-border-black">
-            <h3 class="card-title text-dark mt-0">Admission Requirements</h3>
+      <div className="row row-cols-1 row-cols-sm-2 my-5">
+        <div className="card border-0 mb-4 col">
+          <div className="card-body p-4 uog-blue-muted uog-border-black">
+            <h3 className="card-title text-dark mt-0">Admission Requirements</h3>
             <p>
               Explore admission requirements for Canadian, international, transfer, and mature students. Start your
               journey today!
@@ -84,9 +84,9 @@ function renderAdmissionRequirements() {
           </div>
         </div>
 
-        <div class="card border-0 mb-4 col">
-          <div class="card-body p-4 uog-blue-muted uog-border-red">
-            <h3 class="card-title text-dark mt-0">Scholarships & Bursaries</h3>
+        <div className="card border-0 mb-4 col">
+          <div className="card-body p-4 uog-blue-muted uog-border-red">
+            <h3 className="card-title text-dark mt-0">Scholarships & Bursaries</h3>
             <p>
               We offer a wide range of financial aid programs to assist with funding your education at the University of
               Guelph.
@@ -99,9 +99,9 @@ function renderAdmissionRequirements() {
           </div>
         </div>
 
-        <div class="card border-0 mb-4 col">
-          <div class="card-body p-4 uog-blue-muted uog-border-yellow">
-            <h3 class="card-title text-dark mt-0">Tour Our Campus</h3>
+        <div className="card border-0 mb-4 col">
+          <div className="card-body p-4 uog-blue-muted uog-border-yellow">
+            <h3 className="card-title text-dark mt-0">Tour Our Campus</h3>
             <p>
               Through virtual tours, presentations, webinars and in-person tours, get familiar with the University of
               Guelph campus.
@@ -112,9 +112,9 @@ function renderAdmissionRequirements() {
           </div>
         </div>
 
-        <div class="card border-0 mb-4 col">
-          <div class="card-body p-4 uog-blue-muted uog-border-blue">
-            <h3 class="card-title text-dark mt-0">Have Questions?</h3>
+        <div className="card border-0 mb-4 col">
+          <div className="card-body p-4 uog-blue-muted uog-border-blue">
+            <h3 className="card-title text-dark mt-0">Have Questions?</h3>
             <p>
               Learn more about how to connect, discover, and engage with programs, facilities and life at the University
               of Guelph.

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -355,33 +355,35 @@ const ProgramPage = ({ data, location }) => {
 
       {/**** Call to Actions ****/}
       {callToActionData.length !== 0 && (
-        <div className="container page-container apply-footer">
-          <section className="row row-with-vspace site-content">
-            <div className="col-sm-12 col-md-8 offset-md-3 col-lg-8 mx-auto my-0 content-area">
-              <h3 className="text-dark text-center">Get Future Ready</h3>
-              <div className="d-lg-flex justify-content-lg-between">
-                {(() => {
-                  let isPrimary = true;
-                  return callToActionData.map((cta) => {
-                    const btnClass = isPrimary ? 'btn-primary' : 'btn-outline-primary';
-                    isPrimary = !isPrimary; // Toggle the class for the next item
+        <div className="pt-0 container page-container apply-footer">
+          <div className="col-md-8 mx-auto">
+            <h3 className="mt-0 text-center text-dark">Get Future Ready</h3>
+            <div className="row gx-3 mx-5 mb-5">              
+              {(() => {
+                let isPrimary = true;
+                return callToActionData.map((cta, index) => {
+                  const btnClass = isPrimary ? 'btn-primary' : 'btn-outline-primary';
+                  isPrimary = !isPrimary; // Toggle the class for the next item
 
-                    return (
+                  // Apply mx-auto if there's only one button
+                  const colClass = callToActionData.length === 1 ? 'col-md-6 mx-auto' : 'col-md-6';
+
+                  return (
+                    <div className={colClass} key={cta.drupal_id}>
                       <CallToAction
                         btnClass={btnClass}
-                        key={cta.drupal_id}
                         href={cta.node.field_call_to_action_link.uri}
                         goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}
                         goalEventAction={cta?.node.relationships.field_call_to_action_goal?.field_goal_action}
                       >
                         {cta.node.field_call_to_action_link.title}
                       </CallToAction>
-                    );
-                  });
-                })()}
-              </div>
+                    </div>
+                  );
+                });
+              })()}
             </div>
-          </section>
+          </div>
         </div>
       )}
       {footerData?.length > 0 && <CustomFooter footerData={footerData[0]} />}

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -357,19 +357,21 @@ const ProgramPage = ({ data, location }) => {
       {callToActionData.length !== 0 && (
         <div className="container page-container apply-footer">
           <section className="row row-with-vspace site-content">
-            <div className="col-sm-12 col-md-6 offset-md-3 col-lg-4 offset-lg-4 content-area">
+            <div className="col-sm-12 col-md-8 offset-md-3 col-lg-8 mx-auto my-0 content-area">
               <h3 className="text-dark text-center">Get Future Ready</h3>
-              {callToActionData.map((cta, index) => (
-                <CallToAction
-                  btnClass = {index === (callToActionData.length - 1) ? 'btn-primary':'btn-outline-primary'}
-                  key={index}
-                  href={cta.node.field_call_to_action_link.uri}
-                  goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}
-                  goalEventAction={cta?.node.relationships.field_call_to_action_goal?.field_goal_action}
-                >
-                  {cta.node.field_call_to_action_link.title}
-                </CallToAction>
-              ))}
+              <div class="d-lg-flex justify-content-lg-between">
+                {callToActionData.map((cta, index) => (
+                  <CallToAction
+                    btnClass = {index === (callToActionData.length - 1) ? 'btn-primary':'btn-outline-primary'}
+                    key={index}
+                    href={cta.node.field_call_to_action_link.uri}
+                    goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}
+                    goalEventAction={cta?.node.relationships.field_call_to_action_goal?.field_goal_action}
+                  >
+                    {cta.node.field_call_to_action_link.title}
+                  </CallToAction>
+                ))}
+              </div>
             </div>
           </section>
         </div>

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -360,10 +360,10 @@ const ProgramPage = ({ data, location }) => {
             <h3 className="mt-0 text-center text-dark">Get Future Ready</h3>
             <div className="row gx-3 mx-5 mb-5">              
               {(() => {
-                let isPrimary = true;
-                return callToActionData.map((cta, index) => {
-                  const btnClass = isPrimary ? 'btn-primary' : 'btn-outline-primary';
-                  isPrimary = !isPrimary; // Toggle the class for the next item
+                let isFirstButton = true;
+                return callToActionData.map((cta) => {
+                  const btnClass = isFirstButton ? 'btn-primary' : 'btn-outline-primary';
+                  isFirstButton = false; // Set the flag to false after the first button
 
                   // Apply mx-auto if there's only one button
                   const colClass = callToActionData.length === 1 ? 'col-md-6 mx-auto' : 'col-md-6';

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -359,18 +359,26 @@ const ProgramPage = ({ data, location }) => {
           <section className="row row-with-vspace site-content">
             <div className="col-sm-12 col-md-8 offset-md-3 col-lg-8 mx-auto my-0 content-area">
               <h3 className="text-dark text-center">Get Future Ready</h3>
-              <div class="d-lg-flex justify-content-lg-between">
-                {callToActionData.map((cta, index) => (
-                  <CallToAction
-                    btnClass = {index === (callToActionData.length - 1) ? 'btn-primary':'btn-outline-primary'}
-                    key={index}
-                    href={cta.node.field_call_to_action_link.uri}
-                    goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}
-                    goalEventAction={cta?.node.relationships.field_call_to_action_goal?.field_goal_action}
-                  >
-                    {cta.node.field_call_to_action_link.title}
-                  </CallToAction>
-                ))}
+              <div className="d-lg-flex justify-content-lg-between">
+                {(() => {
+                  let isPrimary = true;
+                  return callToActionData.map((cta) => {
+                    const btnClass = isPrimary ? 'btn-primary' : 'btn-outline-primary';
+                    isPrimary = !isPrimary; // Toggle the class for the next item
+
+                    return (
+                      <CallToAction
+                        btnClass={btnClass}
+                        key={cta.drupal_id}
+                        href={cta.node.field_call_to_action_link.uri}
+                        goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}
+                        goalEventAction={cta?.node.relationships.field_call_to_action_goal?.field_goal_action}
+                      >
+                        {cta.node.field_call_to_action_link.title}
+                      </CallToAction>
+                    );
+                  });
+                })()}
               </div>
             </div>
           </section>
@@ -464,6 +472,7 @@ export const query = graphql`
       edges {
         node {
           changed
+          drupal_id
           field_call_to_action_link {
             title
             uri

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -361,6 +361,7 @@ const ProgramPage = ({ data, location }) => {
               <h3 className="text-dark text-center">Get Future Ready</h3>
               {callToActionData.map((cta, index) => (
                 <CallToAction
+                  btnClass = {index === (callToActionData.length - 1) ? 'btn-primary':'btn-outline-primary'}
                   key={index}
                   href={cta.node.field_call_to_action_link.uri}
                   goalEventCategory={cta?.node.relationships.field_call_to_action_goal?.name}


### PR DESCRIPTION
# Summary of changes
Change the layout of the buttons (on the Bachelor of Commerce) from being 2 solid red buttons stacked to one outlined button on the left and one solid red button on the right. Also make "Learn More: all uppercase to match the "APPLY NOW" button.

## Frontend
List all significant changes to Gatsby code:
program-page.js, added code below:
btnClass = {index === (callToActionData.length - 1) ? 'btn-primary':'btn-outline-primary'}
callToAction.js, added line below:
let className = classNames(btnClass,'btn fs-1 me-4 p-4 w-100');



# Test Plan

Check if the Apply Now button change to an outlined button:
https://deploy-preview-274--ugconthub.netlify.app/programs/bachelor-of-commerce/

