### PR TITLE
Add block-bots

### DIFF
--- a/.netlify/edge-functions/block-bots.js
+++ b/.netlify/edge-functions/block-bots.js
@@ -1,0 +1,46 @@
+// inspired (and taken) from ethan marcotte's blog post
+// https://ethanmarcotte.com/wrote/blockin-bots/
+const botUas = [
+  'AdsBot-Google',
+  'Amazonbot',
+  'anthropic-ai',
+  'Applebot',
+  'AwarioRssBot',
+  'AwarioSmartBot',
+  'Bytespider',
+  'CCBot',
+  'ChatGPT',
+  'ChatGPT-User',
+  'Claude-Web',
+  'ClaudeBot',
+  'cohere-ai',
+  'DataForSeoBot',
+  'Diffbot',
+  'FacebookBot',
+  'FacebookBot',
+  'Google-Extended',
+  'GPTBot',
+  'ImagesiftBot',
+  'magpie-crawler',
+  'omgili',
+  'Omgilibot',
+  'peer39_crawler',
+  'PerplexityBot',
+  'python-requests',
+  'YouBot'
+]
+
+export default async (request, context) => {
+  const ua = request.headers.get('user-agent');
+
+  let isBot = false
+
+  botUas.forEach(u => {
+    if (ua.toLowerCase().includes(u.toLowerCase())) {
+      isBot = true
+    }
+  })
+
+  const response = isBot ? new Response(null, { status: 401 }) : await context.next();
+  return response
+};

--- a/.netlify/edge-functions/block-bots.js
+++ b/.netlify/edge-functions/block-bots.js
@@ -16,8 +16,6 @@ const botUas = [
   'cohere-ai',
   'DataForSeoBot',
   'Diffbot',
-  'FacebookBot',
-  'FacebookBot',
   'Google-Extended',
   'GPTBot',
   'ImagesiftBot',

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,7 @@ remote_images = [
   "https://api.devugconthub.uoguelph.dev/.*",
   "https://.*.pantheonsite.io/.*"
 ]
+
+[[edge_functions]]
+function = "block-bots"
+path = "/*"


### PR DESCRIPTION
# Summary of changes
Trying method for block bots using Netlify edge function
https://ethanmarcotte.com/wrote/blockin-bots/ 
https://www.jeremiak.com/blog/block-bots-netlify-edge-functions/

It checks to see if the user agent is part of a list of bots and serves a 401 error if it finds the user agent on the list.

## Frontend
List all significant changes to Gatsby code

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Testing Plan

## Test the Edge function was deployed
1. Check [deploy logs](https://app.netlify.com/sites/ugconthub/deploys/6785893c9a6d2b00087d56fe) to see that block-bots was deployed (should show up as a 2nd edge function deployed in logs)
<img width="1345" alt="image" src="https://github.com/user-attachments/assets/c3182386-4ea0-453a-9d0d-d01da5579198" />
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/2f8c1c15-b5b9-4f90-88f9-2bea717e5388" />

## Test the Edge function locally
You can use this method to switch your user agent in Chrome for testing purposes: https://deploy-preview-281--ugconthub.netlify.app/programs/culture-and-technology-studies/

1. Open Chrome
2. Visit https://deploy-preview-281--ugconthub.netlify.app/programs/culture-and-technology-studies/
3. Open Developer Tools
4. Select the Elements tab
5. On the far right, select the customise and control menu (3 dots, looks like a kebab). Then select More Tools, then Network Conditions.
<img width="436" alt="image" src="https://github.com/user-attachments/assets/7246134d-d04f-4cde-9d4f-a1901694bf7d" />

6. Under Network Conditions, find the User Agent section and deselect "Use browser default"
7. Select Custom and enter "python-requests/2.31.0" as the custom user agent
<img width="865" alt="image" src="https://github.com/user-attachments/assets/8154a1a2-dadb-426a-928e-c059368adfcf" />
8. Refresh the page. It should show a 401 error.
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/74435233-0120-4003-ab7f-da764730fb37" />
9. If you switch back to using the default user agent (i.e., check "Use browser default") and refresh, the page should show up.
