### PR TITLE
Update GraphQL filter to include published and draft content only

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1081,7 +1081,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
     // INSTRUCTION: Create a page for each node by processing the results of your query here
     // Each content type should have its own if statement code snippet
 
-    // ALIASES will contain all url aliases for pages and programs that are NOT archived
+    // ALIASES will contain all url aliases for pages and programs in a Draft or Published state
     let aliases = {};
 
     // process page nodes

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1035,7 +1035,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
 
   const result = await graphql(`
     {
-      pages: allNodePage(filter: { path: { alias: { ne: null } }, moderation_state: { ne: "archived" } }) {
+      pages: allNodePage(filter: { path: { alias: { ne: null } }, moderation_state: { in: ["published", "draft"] } }) {
         edges {
           node {
             id
@@ -1051,7 +1051,7 @@ exports.createPages = async ({ graphql, actions, createNodeId, reporter }) => {
           }
         }
       }
-      programs: allNodeProgram(filter: { path: { alias: { ne: null } }, moderation_state: { ne: "archived" } }) {
+      programs: allNodeProgram(filter: { path: { alias: { ne: null } }, moderation_state: { in: ["published", "draft"] } }) {
         edges {
           node {
             title


### PR DESCRIPTION
# Summary of changes
Once the _Queue for Delete_ multidev is merged, we do not want content with that moderation state to be built. This PR updates the GraphQL filters to exclude all content with a moderation state other than Published or Draft.

## Frontend
- Update `allNodePage` and `allNodeProgram` queries in `gatsby-node.js`

## Backend
URL: https://mm-qdelete-chug.pantheonsite.io/
See the [Queue for Delete workflow Multidev Merge Request](https://teams.microsoft.com/l/message/19:f2ae5b00dc95407d8902b0e04ff98ec1@thread.tacv2/1737650602575?tenantId=be62a12b-2cad-49a1-a5fa-85f4f3156a7d&groupId=cde949b1-e9d8-483b-8d20-e9b8fd9e493d&parentMessageId=1737650602575&teamName=Content%20Hub%20Team&channelName=Multidev%20Merge%20Requests&createdTime=1737650602575) for more details

# Test Plan

Verify the [Content Hub Inventory page](https://deploy-preview-291--preview-ugconthub.netlify.app/) does not list any content with a moderation state of `Archived` or `Queue for Delete`