### PR TITLE
Add trailing slash for lighthouse test urls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,19 +22,19 @@ remote_images = [
     output_path = "reports/accordions.html"
 
   [[plugins.inputs.audits]]
-    path = "programs/bachelor-of-mathematics"
+    path = "programs/bachelor-of-mathematics/"
     output_path = "reports/ba-math.html"
 
   [[plugins.inputs.audits]]
-    path = "programs/bachelor-of-computing"
+    path = "programs/bachelor-of-computing/"
     output_path = "reports/ba-comp.html"
 
   [[plugins.inputs.audits]]
-    path = "programs/bachelor-of-engineering"
+    path = "programs/bachelor-of-engineering/"
     output_path = "reports/ba-eng.html"
 
   [[plugins.inputs.audits]]
-    path = "programs/bachelor-of-science"
+    path = "programs/bachelor-of-science/"
     output_path = "reports/ba-sci.html"
 
   [[plugins.inputs.audits]]


### PR DESCRIPTION
# Summary of changes
Add trailing slash for lighthouse test urls to fix redirect that occurs from no-slash to trailing slash URLs.

## Frontend
None

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Confirm this issue does not show up on lighthouse report:
<img width="870" alt="image" src="https://github.com/user-attachments/assets/31d194b5-52c2-41a6-8522-22ce86869848" />
