### PR TITLE
Exclude Spotlight content type

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,6 +61,10 @@ module.exports = {
         headers: {
           'api-key': process.env.API_KEY,
         },
+        filters: {
+          // Exclude Spotlight content type
+          "node--spotlight": "filter[status][value]=0",
+        },
         fastBuilds: process.env.FASTBUILDS ?? true,
         skipFileDownloads: true,
         requestTimeoutMS: 300000,


### PR DESCRIPTION
# Summary of changes
Prevent spotlight content from being processed by the build in order to prevent [this error on the Preview site](https://app.netlify.com/sites/preview-ugconthub/deploys/67aa6b847f740f0008c013aa):

![image](https://github.com/user-attachments/assets/3b99ad99-07d8-4d27-950f-0ff0852bc4c0)

## Frontend
- Update `gatsby-config.js` to filter spotlight content

## Backend
N/A

# Test Plan
- Go to https://api.devugconthub.uoguelph.dev/
- Delete some spotlight nodes
- Go to https://app.netlify.com/sites/dev-ugconthub/deploys and verify the build completes successfully