### PR TITLE
Roll back row removal and margin-top 0 on media text widget

### DIFF
--- a/src/components/shared/sectionWidgets.js
+++ b/src/components/shared/sectionWidgets.js
@@ -8,7 +8,7 @@ import widgetModules from "components/shared/widgetModules";
 const StatisticWidget = lazy(() => import("components/shared/statisticWidget"));
 
 const templates = {
-  'primary-100': { primary: '', secondary: '' },
+  'primary-100': { primary: 'row', secondary: '' },
   'primary-50-secondary-50': { primary: 'col-md-6 mb-5 mb-md-0', secondary: 'col-md-6'},
   'primary-75-secondary-25': { primary: 'col-md-9 mb-5 mb-md-0', secondary: 'col-md-3'},
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -210,11 +210,6 @@ i.green {
   filter: brightness(0.5);
 }
 
-/* Media & text widget description */
-div[data-title="media-description"] > div > :first-child {
-  margin-top: 0;
-}
-
 /* Quick columns */
 /* the two-col-md class is in UofG-styles.css but can be moved here later */
 


### PR DESCRIPTION
# Issue
- Media & text widgets inside a primary section are no longer appearing properly after last week's changes.
<img width="1551" alt="image" src="https://github.com/user-attachments/assets/303cdcee-b457-4ae6-ac4f-4d89b227b37b" />

- Also the margin-top 0 style that was added last week is causing issues in some cases.
<img width="1560" alt="image" src="https://github.com/user-attachments/assets/c8783119-6cd3-4cca-9c87-7af4fcd2f00c" />


# Summary of changes
- Roll back row removal and margin-top 0 on media text widget 

## Frontend
- Roll back row removal and margin-top 0 on media text widget

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan
1. View /housing/apply/ - https://deploy-preview-297--ugconthub.netlify.app/housing/apply/
2. View /choose-u-of-guelph - https://deploy-preview-297--ugconthub.netlify.app/choose-u-of-guelph

Media & text widgets should appear properly.

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/dd4e04b8-46db-4006-9473-f6acb0ef3a74" />
