### PR TITLE
Remove obsolete program stat styles

### DIFF
--- a/src/styles/stats.css
+++ b/src/styles/stats.css
@@ -104,14 +104,12 @@ body.basic-page div.uog-card:nth-of-type(9n+7) {
 }
 
 @media only screen and (max-width: 768px) {
-	body.program .uog-card,
 	body.basic-page .uog-card {
 		min-width: 50%; 
 		text-align: center;
 		margin-top: 0;
 		margin-bottom: 3rem;
 	}
-	body.program dt,
 	body.basic-page .uog-card dt {
 		font-size: 3.5rem;
 		color: #000;
@@ -120,7 +118,6 @@ body.basic-page div.uog-card:nth-of-type(9n+7) {
 	body.program .uog-card dt svg {
 		height: 4rem;
 	}
-	body.program dd,
 	body.basic-page .uog-card dd {
 		font-weight: 600;
 		font-size: 1.4rem;


### PR DESCRIPTION
# Summary of changes
Fix bug described in https://dev.azure.com/uoguelph/CCS/_sprints/taskboard/WDS%20Team/CCS/Sprint%202025.4?workitem=86314 where stat item text is black in mobile view (only affects Program content type)

## Frontend
- Update `stats.css` to remove obsolete program stat styles

## Backend
N/A

# Test Plan

- Go to https://deploy-preview-299--ugconthub.netlify.app/testprogram/
- Shrink window or use Mobile view via Browser inspector
- Verify text on stat items remains white against the red and black backgrounds