### PR TITLE
Fix spacing for media-text widgets with no wrapper

### DIFF
--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -217,7 +217,7 @@ function MediaText (props) {
 
     return (
     <ConditionalWrapper condition={wrapperCol} wrapper={children => <section data-title="media-text-widget" className={wrapperCol}>{children}</section>}>
-        <div data-title="media" className={mediaCol}>
+        <div data-title="media" className={wrapperCol ? mediaCol : classNames(mediaCol, "mt-3 mb-5")}>
             {videoURL &&
             <Video videoID={videoID}
                 videoTitle={videoTitle}


### PR DESCRIPTION
# Summary of changes
Fix spacing for media-text widgets with no wrapper

Note: This particular example has had artificial whitespace (<br />) to try and fix the issue at the top, but then folks have to keep adding whitespace. This fix makes it so we handle the spacing in the styles. In the below example, I removed the artificial whitespace so you can see what it would look like.

Before:
<img width="1572" alt="image" src="https://github.com/user-attachments/assets/77688871-02dd-400e-a5a0-c3ef1337f424" />

After:
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/d45c364b-ceec-46a4-8532-d2768c59879e" />

## Frontend
Fix spacing for media-text widgets with no wrapper

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Check https://www.uoguelph.ca/brand-evolution/ and compare to deployment URL for https://deploy-preview-306--preview-ugconthub.netlify.app/brand-evolution

When testing, remember that there is artificial space making the margin-top seem bigger in once case than it actually will be. After releasing this, we should remove the extra <br> that was added to compensate. To see what it'll actually look like, you can remove the <br> in dev tools:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/5def4b5f-6a8e-4fee-bcd9-d3568a5a6cef" />


3. Check https://deploy-preview-306--preview-ugconthub.netlify.app/media-and-text-examples/
4. Check https://deploy-preview-306--preview-ugconthub.netlify.app/widget-examples/
5. Check any pages with lots of media and text widgets