### PR TITLE
Add unique ID to buttons

### DIFF
--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -44,6 +44,7 @@ function buttonStyle(styleOfButton) {
 }
 
 function Button(buttonCol, buttonData, buttonSpacing) {
+  const id = buttonData.drupal_id;
   let urlLink = buttonData.field_button_link?.url;
   let buttonLinkTitle = buttonData?.field_formatted_title
     ? buttonData.field_formatted_title.processed
@@ -82,6 +83,8 @@ function Button(buttonCol, buttonData, buttonSpacing) {
     buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses, "d-table-cell");
   }
 
+  console.log(id);
+
   return (
     <React.Fragment key={buttonData.drupal_id}>
       {buttonData.field_cta_heading && (
@@ -93,6 +96,7 @@ function Button(buttonCol, buttonData, buttonSpacing) {
       {urlLink && urlLink.includes("http") ? (
         btnAnalyticsGoal && btnAnalyticsAction ? (
           <a
+            id={id}
             href={urlLink}
             className={buttonClasses}
             onClick={(e) => {
@@ -112,7 +116,7 @@ function Button(buttonCol, buttonData, buttonSpacing) {
             <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
           </a>
         ) : (
-          <a href={urlLink} className={buttonClasses}>
+          <a id={id} href={urlLink} className={buttonClasses}>
             {buttonIcon && (
               <i aria-hidden="true" className={buttonFontAwesomeClasses}>
                 {" "}
@@ -123,6 +127,7 @@ function Button(buttonCol, buttonData, buttonSpacing) {
         )
       ) : btnAnalyticsGoal && btnAnalyticsAction ? (
         <Link
+          id={id}
           to={urlLink}
           className={buttonClasses}
           onClick={(e) => {
@@ -142,7 +147,7 @@ function Button(buttonCol, buttonData, buttonSpacing) {
           <span className={buttonTitleClasses} dangerouslySetInnerHTML={{ __html: buttonLinkTitle }} />
         </Link>
       ) : (
-        <Link to={urlLink} className={buttonClasses}>
+        <Link id={id} to={urlLink} className={buttonClasses}>
           {buttonIcon && (
             <i aria-hidden="true" className={buttonFontAwesomeClasses}>
               {" "}

--- a/src/components/shared/button.js
+++ b/src/components/shared/button.js
@@ -83,8 +83,6 @@ function Button(buttonCol, buttonData, buttonSpacing) {
     buttonFontAwesomeClasses = classNames(buttonFontAwesomeClasses, "d-table-cell");
   }
 
-  console.log(id);
-
   return (
     <React.Fragment key={buttonData.drupal_id}>
       {buttonData.field_cta_heading && (


### PR DESCRIPTION
# Summary of changes
Add Drupal uuid as html id for buttons rendered via the buttons section widget.

This is to make it easier to track button click events in GA4

## Frontend
List all significant changes to Gatsby code

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to any page with a buttons section ex. https://deploy-preview-316--ugconthub.netlify.app/choose-u-of-guelph/
2. Use Web Inspector on the buttons to check the ID of the buttons is set to a uuid