### PR TITLE
Fix focus element for links widget and colour contrast on legacy class

### DIFF
--- a/src/styles/links.module.css
+++ b/src/styles/links.module.css
@@ -47,7 +47,7 @@
 }
 
 .outer ul.inner li a {
-  display: block;
+  display: inline-block;
 }
 
 @media (min-width: 576px) {

--- a/src/styles/stats.css
+++ b/src/styles/stats.css
@@ -22,6 +22,10 @@ body.basic-page .uog-card {
 	min-width: 25%;
 }
 
+body.basic-page .uog-card a {
+	color: var(--uog-color-body-copy-link-on-light);
+}
+
 body.program .uog-card dt,
 body.basic-page .uog-card dt {
 	font-size: 5rem;


### PR DESCRIPTION
# Summary of changes
- Fixes the size of the focus element for links widget (when it's a link instead of a grid box)

Before:
![image](https://github.com/user-attachments/assets/01454e73-5a1c-4f24-8dbe-c54e6fcc63a6)

After:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/35262252-84b4-4ea2-8a45-7ae3a5e2007c" />

- Fixes colour contrast when folks use links inside a .uog-card element
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/66ac341b-26d6-4c9d-a969-edc14adfd691" />

## Frontend
- Fixes the size of the focus element for links widget (when it's a link instead of a grid box)
- Fixes colour contrast when folks use links inside a .uog-card element

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

For link focus, use:
- https://mmafe-dev.netlify.app/widget-examples/
- https://mmafe-dev.netlify.app/media-and-text-examples/
- For contrast issues for links inside .uog-card element, test with https://mmafe-dev.netlify.app/lang/research/