### PR TITLE
Deco img

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -603,6 +603,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_media_alignment: String
       field_media_text_desc: BodyField
       field_media_text_title: String
+      field_media_is_decorative: Boolean
       field_heading_level: String
       relationships: paragraph__media_textRelationships
     }

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -54,6 +54,7 @@ function MediaText (props) {
     const imageAlt = props.data?.relationships?.field_media_text_media?.field_media_image?.alt ?? "";
     const mediaSize = props.data?.field_media_image_size;
     const mediaAlignment = props.data?.field_media_alignment ?? 'left';
+    const mediaIsDecorative = props.data?.field_media_is_decorative;
 
     const videoTitle = props.data?.relationships.field_media_text_media?.name;
     const videoTranscript = mediaRelationships?.field_media_file?.publicUrl;
@@ -255,6 +256,7 @@ export const query = graphql`
     field_media_image_size
     field_media_alignment
     field_media_text_title
+    field_media_is_decorative
     field_heading_level
     field_media_text_desc {
       processed

--- a/src/components/shared/mediaText.js
+++ b/src/components/shared/mediaText.js
@@ -213,7 +213,7 @@ function MediaText (props) {
                 videoWidth={videoWidth}
             />}
 
-            {imageURL && <GatsbyImage image={imageURL.gatsbyImage} alt={imageAlt} />}
+            {imageURL && <GatsbyImage image={imageURL.gatsbyImage} alt={mediaIsDecorative ? "" : imageAlt} />}
         </div>
         {textOrButtons &&
         <div data-title="media-description" className={textCol}>


### PR DESCRIPTION
# Summary of changes
Brief description of the proposed changes

## Frontend
List all significant changes to Gatsby code

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
Added boolean field for Decorative images, to the Media & Text widget

# Test Plan
- Go to https://abanerji-dev.netlify.app/registrar/course-selection/restrictions/
- Check the section at the bottom of the page to make alt text is not shown in the second chart image (Decorative Image - no alt)
- https://jb-decoimg-chug.pantheonsite.io/
- Ensure the new field is there in the Media & Text  widget