### PR TITLE
Exclude Profile content type from build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,11 +68,12 @@ module.exports = {
         apiBase: process.env.DRUPAL_APIBASE,
         headers: {
           'api-key': process.env.API_KEY,
-        },
+        },            
         filters: {
           // Exclude Spotlight content type
           "node--spotlight": "filter[status][value]=0",
         },
+        disallowedLinkTypes: ["node--profile"], // Exclude this content type entirely
         fastBuilds: process.env.FASTBUILDS ?? true,
         skipFileDownloads: true,
         requestTimeoutMS: 300000,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,7 +68,7 @@ module.exports = {
         apiBase: process.env.DRUPAL_APIBASE,
         headers: {
           'api-key': process.env.API_KEY,
-        },            
+        },
         filters: {
           // Exclude Spotlight content type
           "node--spotlight": "filter[status][value]=0",


### PR DESCRIPTION
# Summary of changes
Prevent gus from trying to building the Profile content type (which in turn causes all sorts of build errors)

## Frontend
- Update `gatsby-config.js` to explicitly exclude the `node--profile` content type

## Backend
N/A

# Test Plan

Go to https://deploy-preview-329--ugconthub.netlify.app/ and verify random pages work as expected