### PR TITLE
Update metatag description logic to comply with latest module version

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -398,7 +398,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       drupal_internal__nid: Int
       field_domain_access: [node__pageField_domain_access]
       field_hero_image: ImageField
-      metatag: node__pageMetatag
+      metatag: [node__pageMetatag]
       relationships: node__pageRelationships
       fields: FieldsPathAlias
       path: AliasPath
@@ -411,6 +411,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type node__pageMetatagAttributes implements Node {
       content: String
+      property: String
     }
     type node__pageRelationships implements Node {
       field_hero_image: media__image @link(from: "field_hero_image___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -398,7 +398,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       drupal_internal__nid: Int
       field_domain_access: [node__pageField_domain_access]
       field_hero_image: ImageField
-      field_metatags: node__pageField_metatags
+      metatag: node__pageMetatag
       relationships: node__pageRelationships
       fields: FieldsPathAlias
       path: AliasPath
@@ -406,8 +406,11 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type node__pageField_domain_access implements Node {
       drupal_internal__target_id: String
     }
-    type node__pageField_metatags implements Node {
-      og_description: String
+    type node__pageMetatag implements Node {
+      attributes: node__pageMetatagAttributes
+    }
+    type node__pageMetatagAttributes implements Node {
+      content: String
     }
     type node__pageRelationships implements Node {
       field_hero_image: media__image @link(from: "field_hero_image___NODE")

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -432,8 +432,8 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_course_notes: node__programField_course_notes
       field_domain_access: [node__programField_domain_access]
       field_prog_image: ImageField
-      field_metatags: node__programField_metatags
       field_program_overview: node__programField_program_overview
+      metatag: [node__programMetatag]
       relationships: node__programRelationships
       fields: FieldsPathAlias
       path: AliasPath
@@ -446,13 +446,17 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     type node__programField_domain_access implements Node {
       drupal_internal__target_id: String
     }
-    type node__programField_metatags implements Node {
-      og_description: String
-    }
     type node__programField_program_overview implements Node {
       value: String
       format: String
       processed: String
+    }
+    type node__programMetatag implements Node {
+      attributes: node__programMetatagAttributes
+    }
+    type node__programMetatagAttributes implements Node {
+      content: String
+      property: String
     }
     type node__programRelationships implements Node {
       field_program_acronym: taxonomy_term__programs @link(from: "field_program_acronym___NODE")

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-starter-ug",
   "private": true,
   "description": "U of G starter for Gatsby",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "license": "MIT",
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-starter-ug",
   "private": true,
   "description": "U of G starter for Gatsby",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "license": "MIT",
   "scripts": {
     "build": "gatsby build --prefix-paths",

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -13,7 +13,7 @@ const Breadcrumbs = lazy(() => import('components/shared/breadcrumbs'));
 
 const Page = ({nodeID, pageTitle, seoData, heroData, widgets, footer, menuData, domains}) => {
   const hasHeroContent = heroData.imageData?.length > 0 || heroData.heroWidgets?.length > 0;
-
+    
   return (
     <Layout menuName={menuData.menuName}>
         <Helmet bodyAttributes={{ class: 'basic-page' }} />
@@ -77,6 +77,7 @@ export const query = graphql`
       metatag {
         attributes {
           content
+          property
         }
       }
       path {
@@ -136,7 +137,7 @@ export const query = graphql`
 const PageTemplate = ({data}) => {
     const seoData = {
         title: data.nodePage.title,
-        description: data.nodePage.metatag?.attributes?.content,
+        description: data.nodePage.metatag?.find(tag => tag.attributes?.property === 'og:description')?.attributes?.content,
         img: data.images.edges[0]?.node?.relationships?.field_media_image?.publicUrl,
         imgAlt: data.images.edges[0]?.node?.field_media_image?.alt
     };

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -13,7 +13,7 @@ const Breadcrumbs = lazy(() => import('components/shared/breadcrumbs'));
 
 const Page = ({nodeID, pageTitle, seoData, heroData, widgets, footer, menuData, domains}) => {
   const hasHeroContent = heroData.imageData?.length > 0 || heroData.heroWidgets?.length > 0;
-    
+
   return (
     <Layout menuName={menuData.menuName}>
         <Helmet bodyAttributes={{ class: 'basic-page' }} />

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -74,8 +74,10 @@ export const query = graphql`
       field_domain_access {
         drupal_internal__target_id
       }
-      field_metatags {
-        og_description
+      metatag {
+        attributes {
+          content
+        }
       }
       path {
         alias
@@ -134,7 +136,7 @@ export const query = graphql`
 const PageTemplate = ({data}) => {
     const seoData = {
         title: data.nodePage.title,
-        description: data.nodePage.field_metatags?.og_description,
+        description: data.nodePage.metatag?.attributes?.content,
         img: data.images.edges[0]?.node?.relationships?.field_media_image?.publicUrl,
         imgAlt: data.images.edges[0]?.node?.field_media_image?.alt
     };

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -302,7 +302,7 @@ const ProgramPageTemplate = ({data}) => {
 
   const seoData = {
     title: progData.title,
-    description: progData.field_metatags?.og_description,
+    description: progData.metatag?.find(tag => tag.attributes?.property === 'og:description')?.attributes?.content,
     img: heroData.images && heroData.images[0]?.node.relationships.field_media_image.publicUrl,
     imgAlt: heroData.images && heroData.images[0]?.node.field_media_image.alt
   };
@@ -352,11 +352,14 @@ export const query = graphql`
           field_domain_access {
             drupal_internal__target_id
           }
-          field_metatags {
-            og_description
-          }
           field_program_overview {
             processed
+          }
+          metatag {
+            attributes {
+              content
+              property
+            }
           }
           relationships {
             field_prog_image {


### PR DESCRIPTION
# Summary of changes
Ensure existing metatag functionality does not break after metatags module upgrade

## Frontend
- Add new metatag schema to `gatsby-node.js`
- Refactor `seoData.description` logic and graphQL queries in `page.js`
- Refactor `seoData.description` logic and graphQL queries in `program-page.js`

## Backend
- https://rm-metatag-chug.pantheonsite.io/
- Upgrade metatags module to latest version

# Test Plan

- Go to https://deploy-preview-332--dev-ugconthub.netlify.app/oac and view source
- Ensure meta description is consistent with the current live version at https://www.uoguelph.ca/oac
- Go to https://deploy-preview-332--dev-ugconthub.netlify.app/programs/bachelor-of-arts-general/ and view source
- Ensure meta description is consistent with the current live version at https://www.uoguelph.ca/programs/bachelor-of-arts-general/