### PR TITLE
Allow array in field_hero_widgets

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -415,7 +415,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
     }
     type node__pageRelationships implements Node {
       field_hero_image: media__image @link(from: "field_hero_image___NODE")
-      field_hero_widgets: widgetParagraphUnion @link(from:"field_hero_widgets___NODE")
+      field_hero_widgets: [widgetParagraphUnion] @link(from:"field_hero_widgets___NODE")
       field_widgets: [widgetParagraphUnion] @link(from:"field_widgets___NODE")
       field_tags: [relatedTaxonomyUnion] @link(from: "field_tags___NODE")
       field_primary_navigation: taxonomy_term__primary_navigation @link(from: "field_primary_navigation___NODE")
@@ -467,7 +467,7 @@ exports.createSchemaCustomization = ({ actions, schema }) => {
       field_specializations: [taxonomy_term__specializations] @link(from: "field_specializations___NODE")
       field_tags: [taxonomy_term__tags] @link(from: "field_tags___NODE")
       field_prog_image: media__image @link(from: "field_prog_image___NODE")
-      field_hero_widgets: widgetParagraphUnion @link(from:"field_hero_widgets___NODE")
+      field_hero_widgets: [widgetParagraphUnion] @link(from:"field_hero_widgets___NODE")
       field_widgets: [widgetParagraphUnion] @link(from:"field_widgets___NODE")
     }
     type node__testimonial implements Node {

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -144,7 +144,7 @@ const PageTemplate = ({data}) => {
 
     const heroData = {
         imageData: data.images.edges,
-        heroWidgets: data.nodePage.relationships?.field_hero_widgets ? [data.nodePage.relationships.field_hero_widgets] : null
+        heroWidgets: data.nodePage.relationships?.field_hero_widgets,
     };
 
     const footerData = data.footer.edges;

--- a/src/templates/program-page.js
+++ b/src/templates/program-page.js
@@ -291,12 +291,10 @@ const ProgramPageTemplate = ({data}) => {
   const imageData = data.images?.edges;
   const imageTaggedData = data.imagesTagged?.edges
   const variantData = progData.relationships?.field_program_variants;
-
-  // Re: Hero Widgets - `field_hero_widgets` only allows a single widget (at the moment), and
-  // Drupal doesn't return an array, so force it into an array.
+  
   const heroData = {
     images: imageData?.length > 0 ? imageData : imageTaggedData?.length > 0 ? imageTaggedData : null,
-    widgets: progData.relationships?.field_hero_widgets ? [progData.relationships?.field_hero_widgets] : null,
+    widgets: progData.relationships?.field_hero_widgets,
     videos: data.videos.edges[0]?.node,
   }
 


### PR DESCRIPTION
# Summary of changes
Allow array in field_hero_widgets

## Frontend
- Allow array in field_hero_widgets
- Update basic page and program templates to account for array

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# CAVEAT
If run directly against the live site, this PR deployment fails (because the hero widget is not yet an array). For now I have temporarily switched the PR deployments to point to the release multidev mm-jul7ogps.

# Test Plan

## Test with NO OGPS content (i.e., no terms, no nodes, nothing) - mm-jul7ogps multidev
1. Confirm modal video works on BASIC PAGE: https://6a4d0eb59f187f0008b74068--mmafe-dev.netlify.app/studentexperience/
1. Confirm modal video works on PROGRAM template: https://6a4d0eb59f187f0008b74068--mmafe-dev.netlify.app/programs/bachelor-of-applied-science/

## Test WITH OGPS content (i.e., terms, nodes, variants on pages) - ogps-pro multidev
1. Confirm modal video works on BASIC PAGE: https://6a4d157bd4a0ab967ae8b98a--mmafe-dev.netlify.app/studentexperience/
1. Confirm modal video works on PROGRAM template: https://6a4d157bd4a0ab967ae8b98a--mmafe-dev.netlify.app/programs/bachelor-of-applied-science/
1. 4. Confirm graduate program variant DOES NOT SHOW on page with modal video: https://6a4d157bd4a0ab967ae8b98a--mmafe-dev.netlify.app/programs/master-of-biotechnology/